### PR TITLE
geom_alt props

### DIFF
--- a/data/421/166/639/421166639.geojson
+++ b/data/421/166/639/421166639.geojson
@@ -164,6 +164,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459008697,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"846e899f06500746aff73735d87b4d1e",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":421166639,
-    "wof:lastmodified":1566617547,
+    "wof:lastmodified":1582316802,
     "wof:name":"Nor Chichas",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/168/083/421168083.geojson
+++ b/data/421/168/083/421168083.geojson
@@ -162,6 +162,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459008753,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bfd9dea8b4f6649bf82bd7f074e62489",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":421168083,
-    "wof:lastmodified":1566617545,
+    "wof:lastmodified":1582316802,
     "wof:name":"Sur Yungas",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/169/177/421169177.geojson
+++ b/data/421/169/177/421169177.geojson
@@ -538,6 +538,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459008797,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d5323fb1b27330c4cc9e489d912dd2b",
     "wof:hierarchy":[
         {
@@ -549,7 +552,7 @@
         }
     ],
     "wof:id":421169177,
-    "wof:lastmodified":1566617558,
+    "wof:lastmodified":1582316806,
     "wof:name":"Sucre",
     "wof:parent_id":421190241,
     "wof:placetype":"locality",

--- a/data/421/169/225/421169225.geojson
+++ b/data/421/169/225/421169225.geojson
@@ -162,6 +162,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459008800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7f26168c2ac63ec35e144e1c183c410",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":421169225,
-    "wof:lastmodified":1566617557,
+    "wof:lastmodified":1582316806,
     "wof:name":"Belisario Boeto",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/421/169/227/421169227.geojson
+++ b/data/421/169/227/421169227.geojson
@@ -161,6 +161,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459008800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"628d607563cde35245fc4bbe82b608a1",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":421169227,
-    "wof:lastmodified":1566617555,
+    "wof:lastmodified":1582316805,
     "wof:name":"Tomina",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/421/169/233/421169233.geojson
+++ b/data/421/169/233/421169233.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459008800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9e9d876ff7c752bd61962d0c4173742",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421169233,
-    "wof:lastmodified":1566617557,
+    "wof:lastmodified":1582316806,
     "wof:name":"Cercado",
     "wof:parent_id":85669431,
     "wof:placetype":"county",

--- a/data/421/169/235/421169235.geojson
+++ b/data/421/169/235/421169235.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459008800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2163edec3cdc14e3aba77b0041243e2f",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421169235,
-    "wof:lastmodified":1566617556,
+    "wof:lastmodified":1582316805,
     "wof:name":"Gran Chaco",
     "wof:parent_id":85669431,
     "wof:placetype":"county",

--- a/data/421/172/489/421172489.geojson
+++ b/data/421/172/489/421172489.geojson
@@ -161,6 +161,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459008944,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c34d56f81e7c5c31af4d037323bddc76",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":421172489,
-    "wof:lastmodified":1566617568,
+    "wof:lastmodified":1582316809,
     "wof:name":"Chapare",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/421/175/057/421175057.geojson
+++ b/data/421/175/057/421175057.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009053,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e400878308c9b3345600a82c5ba5c406",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421175057,
-    "wof:lastmodified":1566617573,
+    "wof:lastmodified":1582316810,
     "wof:name":"Enrique Baldivieso",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/176/731/421176731.geojson
+++ b/data/421/176/731/421176731.geojson
@@ -399,6 +399,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009117,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b0cbdcdc22b0ab15307337b6c23047a",
     "wof:hierarchy":[
         {
@@ -410,7 +413,7 @@
         }
     ],
     "wof:id":421176731,
-    "wof:lastmodified":1566617590,
+    "wof:lastmodified":1582316817,
     "wof:name":"La Paz",
     "wof:parent_id":421177667,
     "wof:placetype":"locality",

--- a/data/421/177/651/421177651.geojson
+++ b/data/421/177/651/421177651.geojson
@@ -158,6 +158,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009156,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec8ac2559838f404588e7576996c65fe",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":421177651,
-    "wof:lastmodified":1566617580,
+    "wof:lastmodified":1582316812,
     "wof:name":"German Jordan",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/421/177/655/421177655.geojson
+++ b/data/421/177/655/421177655.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009156,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d610ae55ba8567430aaca37a93fc5d8",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421177655,
-    "wof:lastmodified":1566617585,
+    "wof:lastmodified":1582316815,
     "wof:name":"Federico Roman",
     "wof:parent_id":85669417,
     "wof:placetype":"county",

--- a/data/421/177/657/421177657.geojson
+++ b/data/421/177/657/421177657.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009156,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d04f5f640cf4448f21f9597b4a0a2796",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":421177657,
-    "wof:lastmodified":1566617584,
+    "wof:lastmodified":1582316814,
     "wof:name":"Antonio Quijarro",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/177/659/421177659.geojson
+++ b/data/421/177/659/421177659.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009157,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a55b49d9ee6e5d8416f1a455be9fbcbe",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":421177659,
-    "wof:lastmodified":1566617581,
+    "wof:lastmodified":1582316813,
     "wof:name":"Daniel Campos",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/177/661/421177661.geojson
+++ b/data/421/177/661/421177661.geojson
@@ -173,6 +173,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009157,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d89ca9d3b2c698dc7922dad294a77179",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
         }
     ],
     "wof:id":421177661,
-    "wof:lastmodified":1566617584,
+    "wof:lastmodified":1582316814,
     "wof:name":"Modesto Omiste",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/177/665/421177665.geojson
+++ b/data/421/177/665/421177665.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009157,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29de610926057d66fe1621895b8df07c",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":421177665,
-    "wof:lastmodified":1566617585,
+    "wof:lastmodified":1582316815,
     "wof:name":"Tomas Frias",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/177/667/421177667.geojson
+++ b/data/421/177/667/421177667.geojson
@@ -162,6 +162,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009157,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f562dd49fbd5025ca0e04715a9fa28e6",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":421177667,
-    "wof:lastmodified":1566617580,
+    "wof:lastmodified":1582316812,
     "wof:name":"Murillo",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/178/897/421178897.geojson
+++ b/data/421/178/897/421178897.geojson
@@ -76,6 +76,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009197,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8fcae3b1c2da525c35d0e1f8b46ad97b",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":421178897,
-    "wof:lastmodified":1566617587,
+    "wof:lastmodified":1582316815,
     "wof:name":"Puerto Quijarro",
     "wof:parent_id":421183095,
     "wof:placetype":"localadmin",

--- a/data/421/180/937/421180937.geojson
+++ b/data/421/180/937/421180937.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009276,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"40898bf594f95930f766e2b4055826d6",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421180937,
-    "wof:lastmodified":1566617562,
+    "wof:lastmodified":1582316807,
     "wof:name":"San Pedro de Quemes",
     "wof:parent_id":421193357,
     "wof:placetype":"localadmin",

--- a/data/421/182/435/421182435.geojson
+++ b/data/421/182/435/421182435.geojson
@@ -164,6 +164,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009329,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b282814d9c39babf15913b2100c6fea",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":421182435,
-    "wof:lastmodified":1566617589,
+    "wof:lastmodified":1582316816,
     "wof:name":"Loayza",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/182/437/421182437.geojson
+++ b/data/421/182/437/421182437.geojson
@@ -161,6 +161,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009329,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"016bf0b7032b703bab8515170c8163e1",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":421182437,
-    "wof:lastmodified":1566617587,
+    "wof:lastmodified":1582316816,
     "wof:name":"Munecas",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/182/439/421182439.geojson
+++ b/data/421/182/439/421182439.geojson
@@ -147,6 +147,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009330,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bd3bf726aecc21f9d1bf6a568504825d",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":421182439,
-    "wof:lastmodified":1566617587,
+    "wof:lastmodified":1582316815,
     "wof:name":"Pacajes",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/182/443/421182443.geojson
+++ b/data/421/182/443/421182443.geojson
@@ -151,6 +151,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009330,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ecd809078e140d9e5f71c8e3e22ab3f2",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":421182443,
-    "wof:lastmodified":1566617588,
+    "wof:lastmodified":1582316816,
     "wof:name":"Arce",
     "wof:parent_id":85669431,
     "wof:placetype":"county",

--- a/data/421/183/095/421183095.geojson
+++ b/data/421/183/095/421183095.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009357,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23620db4d5e4d6e36a78fc16d6d9ee43",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421183095,
-    "wof:lastmodified":1566617586,
+    "wof:lastmodified":1582316815,
     "wof:name":"German Busch",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/421/183/869/421183869.geojson
+++ b/data/421/183/869/421183869.geojson
@@ -192,6 +192,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009389,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"d61f69278d444cb4aaae121ad36bac9a",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":421183869,
-    "wof:lastmodified":1566617586,
+    "wof:lastmodified":1582316815,
     "wof:name":"San Javier",
     "wof:parent_id":1092009873,
     "wof:placetype":"locality",

--- a/data/421/184/251/421184251.geojson
+++ b/data/421/184/251/421184251.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009405,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cbe1ad36e92a4994f3df81724168268d",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421184251,
-    "wof:lastmodified":1566617579,
+    "wof:lastmodified":1582316812,
     "wof:name":"San Buena Ventura",
     "wof:parent_id":421190245,
     "wof:placetype":"localadmin",

--- a/data/421/184/649/421184649.geojson
+++ b/data/421/184/649/421184649.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009418,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"42d71e4e0f82c5063fb9a689eac20ec7",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":421184649,
-    "wof:lastmodified":1566617579,
+    "wof:lastmodified":1582316812,
     "wof:name":"Achocalla",
     "wof:parent_id":421177667,
     "wof:placetype":"localadmin",

--- a/data/421/185/047/421185047.geojson
+++ b/data/421/185/047/421185047.geojson
@@ -164,6 +164,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009431,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"895ca88a9bbcf6184d7b58c01cace9b9",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":421185047,
-    "wof:lastmodified":1566617591,
+    "wof:lastmodified":1582316817,
     "wof:name":"Esteban Arce",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/421/186/229/421186229.geojson
+++ b/data/421/186/229/421186229.geojson
@@ -161,6 +161,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009474,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"62311cc61a96196c5f12acf9efc6b7b3",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":421186229,
-    "wof:lastmodified":1566617569,
+    "wof:lastmodified":1582316809,
     "wof:name":"Manuel M. Caballero",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/421/186/665/421186665.geojson
+++ b/data/421/186/665/421186665.geojson
@@ -211,6 +211,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009488,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"380fb6dacc16a9866c6ec100a0afbe83",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":421186665,
-    "wof:lastmodified":1566617571,
+    "wof:lastmodified":1582316810,
     "wof:name":"La Santisima Trinidad",
     "wof:parent_id":421191613,
     "wof:placetype":"locality",

--- a/data/421/187/093/421187093.geojson
+++ b/data/421/187/093/421187093.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009501,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dae191311bb305bc5f37c17788ecbb88",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421187093,
-    "wof:lastmodified":1566617563,
+    "wof:lastmodified":1582316807,
     "wof:name":"Franz Tamayo",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/187/909/421187909.geojson
+++ b/data/421/187/909/421187909.geojson
@@ -164,6 +164,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009527,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56868f8c85ec3280e27d36404e0650f3",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":421187909,
-    "wof:lastmodified":1566617562,
+    "wof:lastmodified":1582316807,
     "wof:name":"Manco Kapac",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/187/923/421187923.geojson
+++ b/data/421/187/923/421187923.geojson
@@ -189,6 +189,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009528,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56c5b8c346b001f0788358e4a30bc374",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":421187923,
-    "wof:lastmodified":1566617563,
+    "wof:lastmodified":1582316807,
     "wof:name":"Andres Ibanez",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/421/187/927/421187927.geojson
+++ b/data/421/187/927/421187927.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009528,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b0f3f1bdece70342e4b4b60602580b30",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421187927,
-    "wof:lastmodified":1566617564,
+    "wof:lastmodified":1582316808,
     "wof:name":"Cercado",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/421/187/929/421187929.geojson
+++ b/data/421/187/929/421187929.geojson
@@ -165,6 +165,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009528,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"71928eaa1126673670f286efbf3c0996",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":421187929,
-    "wof:lastmodified":1566617564,
+    "wof:lastmodified":1582316808,
     "wof:name":"Larecaja",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/188/855/421188855.geojson
+++ b/data/421/188/855/421188855.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009583,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed6f25a2c34d6054868ba504db07860b",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":421188855,
-    "wof:lastmodified":1566617566,
+    "wof:lastmodified":1582316809,
     "wof:name":"Yamparaez",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/421/189/293/421189293.geojson
+++ b/data/421/189/293/421189293.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009616,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e8c589d895a3b17b13f4ff136e83be30",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421189293,
-    "wof:lastmodified":1566617566,
+    "wof:lastmodified":1582316809,
     "wof:name":"Sorata",
     "wof:parent_id":421187929,
     "wof:placetype":"localadmin",

--- a/data/421/189/295/421189295.geojson
+++ b/data/421/189/295/421189295.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009616,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8810a5ff69695371cc2e563a2b3ae3e0",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421189295,
-    "wof:lastmodified":1566617566,
+    "wof:lastmodified":1582316809,
     "wof:name":"Atocha",
     "wof:parent_id":1092009203,
     "wof:placetype":"localadmin",

--- a/data/421/189/297/421189297.geojson
+++ b/data/421/189/297/421189297.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009616,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"87ce96544f7a727bb1cf1464cb7e7da9",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421189297,
-    "wof:lastmodified":1566617566,
+    "wof:lastmodified":1582316809,
     "wof:name":"Villamontes",
     "wof:parent_id":421169235,
     "wof:placetype":"localadmin",

--- a/data/421/189/301/421189301.geojson
+++ b/data/421/189/301/421189301.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009616,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e55d4a6ad6f17e1105436f94c8a13505",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189301,
-    "wof:lastmodified":1566617566,
+    "wof:lastmodified":1582316809,
     "wof:name":"Samaipata",
     "wof:parent_id":1092009661,
     "wof:placetype":"localadmin",

--- a/data/421/189/303/421189303.geojson
+++ b/data/421/189/303/421189303.geojson
@@ -85,6 +85,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009617,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"93eb836eb088800c45a302dcea686084",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421189303,
-    "wof:lastmodified":1566617566,
+    "wof:lastmodified":1582316809,
     "wof:name":"Arque",
     "wof:parent_id":1092006343,
     "wof:placetype":"localadmin",

--- a/data/421/190/241/421190241.geojson
+++ b/data/421/190/241/421190241.geojson
@@ -164,6 +164,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009651,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd1d7b22cbd155c776229eea86ed8d6f",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":421190241,
-    "wof:lastmodified":1566617575,
+    "wof:lastmodified":1582316811,
     "wof:name":"Oropeza",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/421/190/243/421190243.geojson
+++ b/data/421/190/243/421190243.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009652,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6754451fed503154be9fb6397f1077e4",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421190243,
-    "wof:lastmodified":1566617574,
+    "wof:lastmodified":1582316810,
     "wof:name":"Cercado",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/421/190/245/421190245.geojson
+++ b/data/421/190/245/421190245.geojson
@@ -168,6 +168,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009652,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cb62c557d5e61d7a86182ec971ee38f8",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":421190245,
-    "wof:lastmodified":1566617574,
+    "wof:lastmodified":1582316810,
     "wof:name":"Abel Iturralde",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/191/613/421191613.geojson
+++ b/data/421/191/613/421191613.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009698,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb39712fdd3be156692d180d490cfce7",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421191613,
-    "wof:lastmodified":1566617573,
+    "wof:lastmodified":1582316810,
     "wof:name":"Cercado",
     "wof:parent_id":85669403,
     "wof:placetype":"county",

--- a/data/421/193/355/421193355.geojson
+++ b/data/421/193/355/421193355.geojson
@@ -170,6 +170,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009768,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00298692f0b038ef89e1a983824bea06",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         }
     ],
     "wof:id":421193355,
-    "wof:lastmodified":1566617550,
+    "wof:lastmodified":1582316803,
     "wof:name":"Sur Lipez",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/193/357/421193357.geojson
+++ b/data/421/193/357/421193357.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009768,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6303330d5b72c949b8997094150c1fed",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":421193357,
-    "wof:lastmodified":1566617553,
+    "wof:lastmodified":1582316804,
     "wof:name":"Nor Lipez",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/193/471/421193471.geojson
+++ b/data/421/193/471/421193471.geojson
@@ -162,6 +162,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009772,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a164eb0add430e65abc19867883bb128",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":421193471,
-    "wof:lastmodified":1566617551,
+    "wof:lastmodified":1582316803,
     "wof:name":"Valle Grande",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/421/194/977/421194977.geojson
+++ b/data/421/194/977/421194977.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009826,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f58ae2d17e3844b4203c6aff6411eaec",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421194977,
-    "wof:lastmodified":1566617550,
+    "wof:lastmodified":1582316803,
     "wof:name":"Tarabuco",
     "wof:parent_id":421188855,
     "wof:placetype":"localadmin",

--- a/data/421/194/979/421194979.geojson
+++ b/data/421/194/979/421194979.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009827,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"932cdd43666fa9cc4989a7e5f5688718",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421194979,
-    "wof:lastmodified":1566617550,
+    "wof:lastmodified":1582316803,
     "wof:name":"Tiraque",
     "wof:parent_id":1092006537,
     "wof:placetype":"localadmin",

--- a/data/421/195/737/421195737.geojson
+++ b/data/421/195/737/421195737.geojson
@@ -177,6 +177,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009857,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"c4a68d913d720f89f1b9222389b6ba0a",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":421195737,
-    "wof:lastmodified":1566617549,
+    "wof:lastmodified":1582316803,
     "wof:name":"Bermejo",
     "wof:parent_id":85669431,
     "wof:placetype":"locality",

--- a/data/421/195/849/421195849.geojson
+++ b/data/421/195/849/421195849.geojson
@@ -85,6 +85,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009861,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8e9002793fbd8bbd39952fe647ae4ec5",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421195849,
-    "wof:lastmodified":1566617549,
+    "wof:lastmodified":1582316803,
     "wof:name":"Laja",
     "wof:parent_id":421197575,
     "wof:placetype":"localadmin",

--- a/data/421/195/853/421195853.geojson
+++ b/data/421/195/853/421195853.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009861,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"342d11f2f16b59b41ca80f9791be6720",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421195853,
-    "wof:lastmodified":1566617549,
+    "wof:lastmodified":1582316803,
     "wof:name":"Tiahuanacu",
     "wof:parent_id":1092007213,
     "wof:placetype":"localadmin",

--- a/data/421/195/855/421195855.geojson
+++ b/data/421/195/855/421195855.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009861,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2fb1cc01b100ed214b1630e2e4717a40",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421195855,
-    "wof:lastmodified":1566617549,
+    "wof:lastmodified":1582316803,
     "wof:name":"San Agust\u00edn",
     "wof:parent_id":421175057,
     "wof:placetype":"localadmin",

--- a/data/421/197/123/421197123.geojson
+++ b/data/421/197/123/421197123.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009903,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f2371f3c7b44e19929ba13a4f5c3dc4",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":421197123,
-    "wof:lastmodified":1566617576,
+    "wof:lastmodified":1582316811,
     "wof:name":"Quillacollo",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/421/197/575/421197575.geojson
+++ b/data/421/197/575/421197575.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009918,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b4c13872631b208329f4b0aeabf77109",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421197575,
-    "wof:lastmodified":1566617576,
+    "wof:lastmodified":1582316811,
     "wof:name":"Los Andes",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/199/287/421199287.geojson
+++ b/data/421/199/287/421199287.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009984,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ccd0bf257a565b26cab15ec31db29eb3",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":421199287,
-    "wof:lastmodified":1534379235,
+    "wof:lastmodified":1582316811,
     "wof:name":"Copacabana",
     "wof:parent_id":1092007659,
     "wof:placetype":"localadmin",

--- a/data/421/199/291/421199291.geojson
+++ b/data/421/199/291/421199291.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009984,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2dec03c0b84e2d1438d75fee5b55b30c",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421199291,
-    "wof:lastmodified":1566617577,
+    "wof:lastmodified":1582316811,
     "wof:name":"Colcha K",
     "wof:parent_id":421193357,
     "wof:placetype":"localadmin",

--- a/data/421/199/423/421199423.geojson
+++ b/data/421/199/423/421199423.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459009988,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6869ecd0d1c8544e8c2e08240fcde29b",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421199423,
-    "wof:lastmodified":1566617577,
+    "wof:lastmodified":1582316811,
     "wof:name":"Arani",
     "wof:parent_id":1092006291,
     "wof:placetype":"localadmin",

--- a/data/421/200/745/421200745.geojson
+++ b/data/421/200/745/421200745.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459010037,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fb5b33e4d201184ffd27814ae2e9dd69",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":421200745,
-    "wof:lastmodified":1566617578,
+    "wof:lastmodified":1582316811,
     "wof:name":"Yotala",
     "wof:parent_id":421190241,
     "wof:placetype":"localadmin",

--- a/data/421/201/345/421201345.geojson
+++ b/data/421/201/345/421201345.geojson
@@ -276,6 +276,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459010069,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"03ed08bbf4e52687b22a32f23b5e4047",
     "wof:hierarchy":[
         {
@@ -287,7 +290,7 @@
         }
     ],
     "wof:id":421201345,
-    "wof:lastmodified":1566617579,
+    "wof:lastmodified":1582316811,
     "wof:name":"Quillacollo",
     "wof:parent_id":421197123,
     "wof:placetype":"locality",

--- a/data/421/202/657/421202657.geojson
+++ b/data/421/202/657/421202657.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459010125,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"152803ae095cf8b97e60f17e06c1f785",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421202657,
-    "wof:lastmodified":1566617560,
+    "wof:lastmodified":1582316807,
     "wof:name":"Santa Rosa",
     "wof:parent_id":1092005669,
     "wof:placetype":"localadmin",

--- a/data/421/202/729/421202729.geojson
+++ b/data/421/202/729/421202729.geojson
@@ -198,6 +198,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459010127,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"c05dce3cacf720caa94bc021d0c71349",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":421202729,
-    "wof:lastmodified":1566617560,
+    "wof:lastmodified":1582316807,
     "wof:name":"Apolo",
     "wof:parent_id":421187093,
     "wof:placetype":"locality",

--- a/data/421/202/885/421202885.geojson
+++ b/data/421/202/885/421202885.geojson
@@ -202,6 +202,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459010133,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"c411861027b0c42e697c5d490eb7dc1e",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":421202885,
-    "wof:lastmodified":1566617560,
+    "wof:lastmodified":1582316807,
     "wof:name":"Samaipata",
     "wof:parent_id":1092009661,
     "wof:placetype":"locality",

--- a/data/421/204/017/421204017.geojson
+++ b/data/421/204/017/421204017.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"BO",
     "wof:created":1459010171,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea714d043ad6a6911e6ea05c79ca8d35",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421204017,
-    "wof:lastmodified":1566617559,
+    "wof:lastmodified":1582316806,
     "wof:name":"Sajama",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/856/326/23/85632623.geojson
+++ b/data/856/326/23/85632623.geojson
@@ -958,7 +958,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1014,6 +1015,11 @@
     },
     "wof:country":"BO",
     "wof:country_alpha3":"BOL",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"1aa993a7cd749b2a8c95546d1dd9fad0",
     "wof:hierarchy":[
         {
@@ -1032,7 +1038,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1566616022,
+    "wof:lastmodified":1582316773,
     "wof:name":"Bolivia",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/326/23/85632623.geojson
+++ b/data/856/326/23/85632623.geojson
@@ -958,8 +958,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1038,7 +1037,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1582316773,
+    "wof:lastmodified":1583203424,
     "wof:name":"Bolivia",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/693/95/85669395.geojson
+++ b/data/856/693/95/85669395.geojson
@@ -332,6 +332,9 @@
         "wk:page":"Cochabamba Department"
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"447745ab4fc5b8223e8c02839686534b",
     "wof:hierarchy":[
         {
@@ -351,7 +354,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1566616019,
+    "wof:lastmodified":1582316770,
     "wof:name":"Cochabamba",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/693/99/85669399.geojson
+++ b/data/856/693/99/85669399.geojson
@@ -334,6 +334,9 @@
         "wk:page":"Chuquisaca Department"
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"751e7327a94c01f1e0b5de32321320d9",
     "wof:hierarchy":[
         {
@@ -353,7 +356,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1566616020,
+    "wof:lastmodified":1582316771,
     "wof:name":"Chuquisaca",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/03/85669403.geojson
+++ b/data/856/694/03/85669403.geojson
@@ -335,6 +335,9 @@
         "wk:page":"Beni Department"
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3dd2635008c5290f81aa0f8e78eaf22",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1566616005,
+    "wof:lastmodified":1582316761,
     "wof:name":"El Beni",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/09/85669409.geojson
+++ b/data/856/694/09/85669409.geojson
@@ -330,6 +330,9 @@
         "wk:page":"La Paz Department (Bolivia)"
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"620adbbfd1374e67ead71e76b5c1fdc0",
     "wof:hierarchy":[
         {
@@ -349,7 +352,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1566616012,
+    "wof:lastmodified":1582316766,
     "wof:name":"La Paz",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/13/85669413.geojson
+++ b/data/856/694/13/85669413.geojson
@@ -320,6 +320,9 @@
         "wk:page":"Oruro Department"
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6909bfc4f1bd507ddf1a80628ee13ace",
     "wof:hierarchy":[
         {
@@ -339,7 +342,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1566616017,
+    "wof:lastmodified":1582316769,
     "wof:name":"Oruro",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/17/85669417.geojson
+++ b/data/856/694/17/85669417.geojson
@@ -329,6 +329,9 @@
         "wk:page":"Pando Department"
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b276976e0042a5b9519e5c45f407104",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1566616008,
+    "wof:lastmodified":1582316763,
     "wof:name":"Pando",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/21/85669421.geojson
+++ b/data/856/694/21/85669421.geojson
@@ -339,6 +339,9 @@
         "wk:page":"Potos\u00ed Department"
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"416563407620e1d06b21e83b637829ac",
     "wof:hierarchy":[
         {
@@ -358,7 +361,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1566616010,
+    "wof:lastmodified":1582316764,
     "wof:name":"Potos\u00ed",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/27/85669427.geojson
+++ b/data/856/694/27/85669427.geojson
@@ -341,6 +341,9 @@
         "wk:page":"Santa Cruz Department (Bolivia)"
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e923628a0c5ee1ef1547d2600f4990e7",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1566616007,
+    "wof:lastmodified":1582316762,
     "wof:name":"Santa Cruz",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/31/85669431.geojson
+++ b/data/856/694/31/85669431.geojson
@@ -332,6 +332,9 @@
         "wk:page":"Tarija Department"
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4df1f2322efe3202cab886207a2e4694",
     "wof:hierarchy":[
         {
@@ -351,7 +354,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1566616015,
+    "wof:lastmodified":1582316767,
     "wof:name":"Tarija",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/857/643/53/85764353.geojson
+++ b/data/857/643/53/85764353.geojson
@@ -75,6 +75,9 @@
         "qs:id":222198
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6c79689dd320608817b95936e302c02e",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379236,
+    "wof:lastmodified":1582316759,
     "wof:name":"Callampaya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/61/85764361.geojson
+++ b/data/857/643/61/85764361.geojson
@@ -80,6 +80,9 @@
         "wd:id":"Q255177"
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b2530cb589d71426e005249318418352",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379236,
+    "wof:lastmodified":1582316759,
     "wof:name":"Challapampa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/67/85764367.geojson
+++ b/data/857/643/67/85764367.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":211151
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"89d29d45dcc58aeef887c41818549297",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566616004,
+    "wof:lastmodified":1582316759,
     "wof:name":"Chijini",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/71/85764371.geojson
+++ b/data/857/643/71/85764371.geojson
@@ -75,6 +75,9 @@
         "qs:id":887586
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0f1185a3ce59a2b06e30db7fb2314fac",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379236,
+    "wof:lastmodified":1582316759,
     "wof:name":"Pura Pura",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/77/85764377.geojson
+++ b/data/857/643/77/85764377.geojson
@@ -129,6 +129,9 @@
         "qs_pg:id":1082687
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1baa2555c3fbc3eff97b23a1fc199d47",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566616004,
+    "wof:lastmodified":1582316759,
     "wof:name":"San Jorge",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/643/79/85764379.geojson
+++ b/data/857/643/79/85764379.geojson
@@ -98,6 +98,9 @@
         "qs_pg:id":1165251
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b9626da239db7af0ba5309a7aedd7b43",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566616004,
+    "wof:lastmodified":1582316759,
     "wof:name":"Villa Pab\u00f3n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/662/35/85766235.geojson
+++ b/data/857/662/35/85766235.geojson
@@ -188,6 +188,9 @@
         "qs_pg:id":1324513
     },
     "wof:country":"BO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac0de71f155321fe810fdeed7548d919",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566616005,
+    "wof:lastmodified":1582316759,
     "wof:name":"El Alto",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.