### PR TITLE
bo concordances, placetype local, and more

### DIFF
--- a/data/109/200/566/9/1092005669.geojson
+++ b/data/109/200/566/9/1092005669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.397364,
-    "geom:area_square_m":40778313262.043953,
+    "geom:area_square_m":40778321295.10733,
     "geom:bbox":"-67.566214,-15.864973,-66.235217,-11.373438",
     "geom:latitude":-13.870539,
     "geom:longitude":-66.814979,
@@ -159,9 +159,10 @@
         "hasc:id":"BO.EB.GB",
         "wd:id":"Q827"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896770,
-    "wof:geomhash":"b2b2b31c05efd8733500431f6b766c74",
+    "wof:geomhash":"8334b365c0b9301d3dc6c8260498ba32",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":1092005669,
-    "wof:lastmodified":1690860311,
+    "wof:lastmodified":1695886169,
     "wof:name":"General Jose Balliv",
     "wof:parent_id":85669403,
     "wof:placetype":"county",

--- a/data/109/200/571/1/1092005711.geojson
+++ b/data/109/200/571/1/1092005711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.982242,
-    "geom:area_square_m":35867897350.960815,
+    "geom:area_square_m":35867896863.763657,
     "geom:bbox":"-64.319572,-14.358511,-61.527452,-12.428946",
     "geom:latitude":-13.415958,
     "geom:longitude":-63.317514,
@@ -58,9 +58,10 @@
     "wof:concordances":{
         "hasc:id":"BO.EB.VD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896772,
-    "wof:geomhash":"f612484497f55ddaada2993a9e81930e",
+    "wof:geomhash":"c974cb5e687d898bf7f941f521d51698",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092005711,
-    "wof:lastmodified":1627521601,
+    "wof:lastmodified":1695886184,
     "wof:name":"Itenez",
     "wof:parent_id":85669403,
     "wof:placetype":"county",

--- a/data/109/200/575/9/1092005759.geojson
+++ b/data/109/200/575/9/1092005759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.737515,
-    "geom:area_square_m":20916776876.714458,
+    "geom:area_square_m":20916777708.787117,
     "geom:bbox":"-65.34142,-14.23548,-64.203031,-11.889179",
     "geom:latitude":-13.188257,
     "geom:longitude":-64.713271,
@@ -164,9 +164,10 @@
         "hasc:id":"BO.EB.MM",
         "wd:id":"Q832"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896774,
-    "wof:geomhash":"0fc2385217aefc587b722920485300d0",
+    "wof:geomhash":"e689164ebdfa39306bb9c71d54ec1479",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092005759,
-    "wof:lastmodified":1690860320,
+    "wof:lastmodified":1695886181,
     "wof:name":"Mamore",
     "wof:parent_id":85669403,
     "wof:placetype":"county",

--- a/data/109/200/580/5/1092005805.geojson
+++ b/data/109/200/580/5/1092005805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.239768,
-    "geom:area_square_m":14777402636.511433,
+    "geom:area_square_m":14777400543.385757,
     "geom:bbox":"-65.369019,-15.883952,-63.381395,-14.841481",
     "geom:latitude":-15.429334,
     "geom:longitude":-64.395828,
@@ -152,9 +152,10 @@
         "hasc:id":"BO.EB.MR",
         "wd:id":"Q841"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896775,
-    "wof:geomhash":"1a5749ec4ed1ae1aaf4932475c45d53b",
+    "wof:geomhash":"beec9d900aa925376091f12fb8177c0c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":1092005805,
-    "wof:lastmodified":1690860321,
+    "wof:lastmodified":1695886185,
     "wof:name":"Marban",
     "wof:parent_id":85669403,
     "wof:placetype":"county",

--- a/data/109/200/583/9/1092005839.geojson
+++ b/data/109/200/583/9/1092005839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.682717,
-    "geom:area_square_m":20060400883.83287,
+    "geom:area_square_m":20060401740.217575,
     "geom:bbox":"-66.802798,-16.418886,-64.927053,-14.151259",
     "geom:latitude":-15.385513,
     "geom:longitude":-65.620235,
@@ -142,9 +142,10 @@
         "hasc:id":"BO.EB.MX",
         "wd:id":"Q1325710"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896777,
-    "wof:geomhash":"33bcf64de3f328b49ff099a931a4d347",
+    "wof:geomhash":"fc32945e1ad42aca1ab2ee2411c66c5a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1092005839,
-    "wof:lastmodified":1690860335,
+    "wof:lastmodified":1695886207,
     "wof:name":"Moxos",
     "wof:parent_id":85669403,
     "wof:placetype":"county",

--- a/data/109/200/587/7/1092005877.geojson
+++ b/data/109/200/587/7/1092005877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.342192,
-    "geom:area_square_m":16269085073.247162,
+    "geom:area_square_m":16269084618.186062,
     "geom:bbox":"-66.49241,-12.000077,-65.018892,-10.381218",
     "geom:latitude":-11.392536,
     "geom:longitude":-65.73989,
@@ -134,9 +134,10 @@
         "hasc:id":"BO.EB.VD",
         "wd:id":"Q1325798"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896779,
-    "wof:geomhash":"3c16f4d43dc85e3d61850dd637ad7041",
+    "wof:geomhash":"8418cf859c81b0a931289831d2476105",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1092005877,
-    "wof:lastmodified":1690860322,
+    "wof:lastmodified":1695886185,
     "wof:name":"Vaca Diez",
     "wof:parent_id":85669403,
     "wof:placetype":"county",

--- a/data/109/200/587/9/1092005879.geojson
+++ b/data/109/200/587/9/1092005879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.757624,
-    "geom:area_square_m":45165637794.184959,
+    "geom:area_square_m":45165630317.945686,
     "geom:bbox":"-66.526181,-15.89137,-64.997104,-11.999998",
     "geom:latitude":-13.530895,
     "geom:longitude":-65.845485,
@@ -145,9 +145,10 @@
         "hasc:id":"BO.EB.YC",
         "wd:id":"Q290515"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896780,
-    "wof:geomhash":"ea267875f4fb705826f3196992b25f57",
+    "wof:geomhash":"f16611f294cd1f7b867bbfb88c99bfaf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1092005879,
-    "wof:lastmodified":1690860322,
+    "wof:lastmodified":1695886186,
     "wof:name":"Yacuma",
     "wof:parent_id":85669403,
     "wof:placetype":"county",

--- a/data/109/200/588/1/1092005881.geojson
+++ b/data/109/200/588/1/1092005881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.261962,
-    "geom:area_square_m":3043694143.189597,
+    "geom:area_square_m":3043693980.702921,
     "geom:bbox":"-64.776159,-20.485821,-64.280617,-19.557504",
     "geom:latitude":-20.007155,
     "geom:longitude":-64.488159,
@@ -129,9 +129,10 @@
         "hasc:id":"BO.CQ.AZ",
         "wd:id":"Q1477938"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896782,
-    "wof:geomhash":"99fd23b4a38b064465f637a74ab1c8ab",
+    "wof:geomhash":"31a48d42c0dda630f0811ca4db29ea8c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1092005881,
-    "wof:lastmodified":1690860320,
+    "wof:lastmodified":1695886182,
     "wof:name":"Azurduy",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/109/200/592/3/1092005923.geojson
+++ b/data/109/200/592/3/1092005923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.549254,
-    "geom:area_square_m":6370218743.732308,
+    "geom:area_square_m":6370219167.831939,
     "geom:bbox":"-64.337953,-21.003698,-63.804154,-19.467467",
     "geom:latitude":-20.286612,
     "geom:longitude":-64.046777,
@@ -139,9 +139,10 @@
         "hasc:id":"BO.CQ.HS",
         "wd:id":"Q1244642"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896784,
-    "wof:geomhash":"f6ada812c96d16783a19400284802a54",
+    "wof:geomhash":"343e06ece015e1030bcee303ff16ab69",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1092005923,
-    "wof:lastmodified":1690860312,
+    "wof:lastmodified":1695886170,
     "wof:name":"Hernando Siles",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/109/200/595/9/1092005959.geojson
+++ b/data/109/200/595/9/1092005959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.114127,
-    "geom:area_square_m":12904572511.663326,
+    "geom:area_square_m":12904572860.902748,
     "geom:bbox":"-64.012281,-21.0037,-62.191836,-19.030713",
     "geom:latitude":-20.486732,
     "geom:longitude":-63.223673,
@@ -139,9 +139,10 @@
         "hasc:id":"BO.CQ.LC",
         "wd:id":"Q1419381"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896786,
-    "wof:geomhash":"4ab1e51a789fc28c46caf9e767426d04",
+    "wof:geomhash":"c33058316102e6d6d1afb8053ee60826",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1092005959,
-    "wof:lastmodified":1690860312,
+    "wof:lastmodified":1695886170,
     "wof:name":"Luis Calvo",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/109/200/600/3/1092006003.geojson
+++ b/data/109/200/600/3/1092006003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.661952,
-    "geom:area_square_m":7673112714.068584,
+    "geom:area_square_m":7673112852.004519,
     "geom:bbox":"-65.379251,-20.901987,-64.27278,-19.78001",
     "geom:latitude":-20.372282,
     "geom:longitude":-64.914458,
@@ -136,9 +136,10 @@
         "hasc:id":"BO.CQ.NC",
         "wd:id":"Q1420337"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896788,
-    "wof:geomhash":"03b20891c20c66e607909eb468d6df46",
+    "wof:geomhash":"a56ff25c1335d8634d74c49809862931",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1092006003,
-    "wof:lastmodified":1690860331,
+    "wof:lastmodified":1695886198,
     "wof:name":"Nor Cinti",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/109/200/608/7/1092006087.geojson
+++ b/data/109/200/608/7/1092006087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.342867,
-    "geom:area_square_m":3961427262.466003,
+    "geom:area_square_m":3961427250.853469,
     "geom:bbox":"-65.188893,-21.155074,-64.160306,-20.514578",
     "geom:latitude":-20.870846,
     "geom:longitude":-64.581163,
@@ -128,9 +128,10 @@
         "hasc:id":"BO.CQ.SC",
         "wd:id":"Q1420287"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896791,
-    "wof:geomhash":"f966b479b1b2f0ac8ab1151503aaec3f",
+    "wof:geomhash":"9b3297d890568d4809a28bea77ad99c4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092006087,
-    "wof:lastmodified":1690860330,
+    "wof:lastmodified":1695886196,
     "wof:name":"Sud Cinti",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/109/200/612/5/1092006125.geojson
+++ b/data/109/200/612/5/1092006125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147903,
-    "geom:area_square_m":1705590760.034843,
+    "geom:area_square_m":1705590438.970839,
     "geom:bbox":"-65.46675,-21.506912,-65.100056,-20.846957",
     "geom:latitude":-21.155121,
     "geom:longitude":-65.318074,
@@ -128,9 +128,10 @@
         "hasc:id":"BO.CQ.SC",
         "wd:id":"Q1420287"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896792,
-    "wof:geomhash":"7a2239fca71fe37e0295d363c0ee5a3c",
+    "wof:geomhash":"1e503aea6a96ae4268e1889cb6227e6c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092006125,
-    "wof:lastmodified":1690860329,
+    "wof:lastmodified":1695886194,
     "wof:name":"Sur Cinti",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/109/200/624/1/1092006241.geojson
+++ b/data/109/200/624/1/1092006241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.353757,
-    "geom:area_square_m":4136647736.27815,
+    "geom:area_square_m":4136647661.704448,
     "geom:bbox":"-65.065041,-19.669385,-64.478715,-18.483649",
     "geom:latitude":-18.969702,
     "geom:longitude":-64.755456,
@@ -130,9 +130,10 @@
         "hasc:id":"BO.CQ.ZU",
         "wd:id":"Q266010"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896796,
-    "wof:geomhash":"9fb1d3538b1d3b54cd56396c1e28d3af",
+    "wof:geomhash":"ce0ee4bf8f922a2280b1b1f34308c730",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1092006241,
-    "wof:lastmodified":1690860328,
+    "wof:lastmodified":1695886194,
     "wof:name":"Zudanez",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/109/200/629/1/1092006291.geojson
+++ b/data/109/200/629/1/1092006291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04907,
-    "geom:area_square_m":578381731.617196,
+    "geom:area_square_m":578381430.75781,
     "geom:bbox":"-65.811468,-17.708378,-65.435616,-17.491204",
     "geom:latitude":-17.593833,
     "geom:longitude":-65.634658,
@@ -136,9 +136,10 @@
         "hasc:id":"BO.CB.AR",
         "wd:id":"Q1325748"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896798,
-    "wof:geomhash":"a40f1cfb22fddc84ef8381377041fce6",
+    "wof:geomhash":"2d79dc046273709377b513f507c8a212",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1092006291,
-    "wof:lastmodified":1690860316,
+    "wof:lastmodified":1695886176,
     "wof:name":"Arani",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/109/200/634/3/1092006343.geojson
+++ b/data/109/200/634/3/1092006343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091092,
-    "geom:area_square_m":1072316823.989844,
+    "geom:area_square_m":1072316697.893151,
     "geom:bbox":"-66.776089,-17.976158,-66.251083,-17.671911",
     "geom:latitude":-17.821726,
     "geom:longitude":-66.527521,
@@ -133,9 +133,10 @@
         "hasc:id":"BO.CB.AQ",
         "wd:id":"Q1366072"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896800,
-    "wof:geomhash":"670c10a06dae058eb8912b020824d3d0",
+    "wof:geomhash":"0ee03ab2a7531e4c355813e369b681cf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1092006343,
-    "wof:lastmodified":1690860316,
+    "wof:lastmodified":1695886177,
     "wof:name":"Arque",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/109/200/638/1/1092006381.geojson
+++ b/data/109/200/638/1/1092006381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.786444,
-    "geom:area_square_m":9316526641.697477,
+    "geom:area_square_m":9316526073.075935,
     "geom:bbox":"-67.005779,-17.449438,-66.141608,-15.673504",
     "geom:latitude":-16.650816,
     "geom:longitude":-66.604099,
@@ -142,9 +142,10 @@
         "hasc:id":"BO.CB.AY",
         "wd:id":"Q1365999"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896801,
-    "wof:geomhash":"38f1fd337e1e77243d2f169490d58402",
+    "wof:geomhash":"42bc8e99af0e113b4cb0f3c128dfedbc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1092006381,
-    "wof:lastmodified":1690860332,
+    "wof:lastmodified":1695886199,
     "wof:name":"Ayopaya",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/109/200/642/7/1092006427.geojson
+++ b/data/109/200/642/7/1092006427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061593,
-    "geom:area_square_m":724306366.991998,
+    "geom:area_square_m":724306601.725461,
     "geom:bbox":"-66.822097,-18.13621,-66.395397,-17.888336",
     "geom:latitude":-18.005618,
     "geom:longitude":-66.631687,
@@ -137,9 +137,10 @@
         "hasc:id":"BO.CB.AQ",
         "wd:id":"Q1366072"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896803,
-    "wof:geomhash":"e475a84ffe7a52720c8b2fa2f4a9b826",
+    "wof:geomhash":"ca42cd21fa83d6a543cd98e4649ce1d0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1092006427,
-    "wof:lastmodified":1690860314,
+    "wof:lastmodified":1695886645,
     "wof:name":"Bolivar",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/109/200/646/5/1092006465.geojson
+++ b/data/109/200/646/5/1092006465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.501666,
-    "geom:area_square_m":5888905180.517859,
+    "geom:area_square_m":5888904684.672158,
     "geom:bbox":"-65.354904,-18.682883,-64.27749,-17.866714",
     "geom:latitude":-18.31596,
     "geom:longitude":-64.873532,
@@ -132,9 +132,10 @@
         "hasc:id":"BO.CB.CM",
         "wd:id":"Q1360942"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896804,
-    "wof:geomhash":"d24669641a282763a4d67d8d53320b6b",
+    "wof:geomhash":"8435519ef290d044e7fe602eadb0cfd5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1092006465,
-    "wof:lastmodified":1690860329,
+    "wof:lastmodified":1695886195,
     "wof:name":"Campero",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/109/200/649/7/1092006497.geojson
+++ b/data/109/200/649/7/1092006497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083547,
-    "geom:area_square_m":984095374.819761,
+    "geom:area_square_m":984095668.214241,
     "geom:bbox":"-66.393835,-17.951729,-66.107717,-17.472591",
     "geom:latitude":-17.713516,
     "geom:longitude":-66.241323,
@@ -142,9 +142,10 @@
         "hasc:id":"BO.CB.CP",
         "wd:id":"Q1366004"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896806,
-    "wof:geomhash":"2244fe8d8dfc07ae6fba6f43f30feddd",
+    "wof:geomhash":"f6aa9b11032e6323e5acd939e8e8bdda",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1092006497,
-    "wof:lastmodified":1690860327,
+    "wof:lastmodified":1695886192,
     "wof:name":"Capinota",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/109/200/653/7/1092006537.geojson
+++ b/data/109/200/653/7/1092006537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.060719,
-    "geom:area_square_m":12526924833.136499,
+    "geom:area_square_m":12526923779.691933,
     "geom:bbox":"-65.552102,-18.042228,-64.188217,-15.941518",
     "geom:latitude":-17.231167,
     "geom:longitude":-64.899841,
@@ -139,9 +139,10 @@
         "hasc:id":"BO.CB.CR",
         "wd:id":"Q1366060"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896808,
-    "wof:geomhash":"6d77009442fac56f9246140343d55a5c",
+    "wof:geomhash":"8a18f9585b213e16dd1c4f274fb2d9d1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1092006537,
-    "wof:lastmodified":1690860330,
+    "wof:lastmodified":1695886197,
     "wof:name":"Carrasco",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/109/200/669/7/1092006697.geojson
+++ b/data/109/200/669/7/1092006697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.248852,
-    "geom:area_square_m":2926520361.036016,
+    "geom:area_square_m":2926520347.340881,
     "geom:bbox":"-65.829348,-18.40543,-65.233296,-17.671302",
     "geom:latitude":-17.998009,
     "geom:longitude":-65.50788,
@@ -139,9 +139,10 @@
         "hasc:id":"BO.CB.MZ",
         "wd:id":"Q1427763"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896814,
-    "wof:geomhash":"ca8ef16fd7e96bb729324fa81c8acd0d",
+    "wof:geomhash":"6a9a1eb4a5512a231ae199c042159783",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1092006697,
-    "wof:lastmodified":1690860317,
+    "wof:lastmodified":1695886178,
     "wof:name":"Mizque",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/109/200/674/9/1092006749.geojson
+++ b/data/109/200/674/9/1092006749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034551,
-    "geom:area_square_m":407271713.430082,
+    "geom:area_square_m":407271922.272271,
     "geom:bbox":"-65.952655,-17.746418,-65.714915,-17.439376",
     "geom:latitude":-17.579541,
     "geom:longitude":-65.841901,
@@ -145,9 +145,10 @@
         "hasc:id":"BO.CB.PN",
         "wd:id":"Q1424427"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896815,
-    "wof:geomhash":"7489c01fbe06199907ce20cb70923f21",
+    "wof:geomhash":"1da4de12ad1898820b60d64b098663a9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1092006749,
-    "wof:lastmodified":1690860315,
+    "wof:lastmodified":1695886647,
     "wof:name":"Punata",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/109/200/680/5/1092006805.geojson
+++ b/data/109/200/680/5/1092006805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.140136,
-    "geom:area_square_m":1651912085.965239,
+    "geom:area_square_m":1651912161.07656,
     "geom:bbox":"-66.932959,-17.794078,-66.38829,-17.366645",
     "geom:latitude":-17.576767,
     "geom:longitude":-66.661235,
@@ -140,9 +140,10 @@
         "hasc:id":"BO.CB.TP",
         "wd:id":"Q277886"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896818,
-    "wof:geomhash":"75eac2fb65f1a23d5ca137a923911ead",
+    "wof:geomhash":"67ac4cbc1d468b5342fa3d2cf88c11a1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1092006805,
-    "wof:lastmodified":1690860315,
+    "wof:lastmodified":1695886175,
     "wof:name":"Tapacari",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/109/200/685/1/1092006851.geojson
+++ b/data/109/200/685/1/1092006851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.232142,
-    "geom:area_square_m":2741153566.707819,
+    "geom:area_square_m":2741153566.708559,
     "geom:bbox":"-65.8566109008,-17.5252013686,-65.1721550236,-16.8588027558",
     "geom:latitude":-17.263929,
     "geom:longitude":-65.463947,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"BO.CB.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896820,
-    "wof:geomhash":"0db16fbbb4ae45dfb2c81cc16558609a",
+    "wof:geomhash":"8352663f10fe0a1b7fb068c346a2a897",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1092006851,
-    "wof:lastmodified":1566617457,
+    "wof:lastmodified":1695886192,
     "wof:name":"Tiraque",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/109/200/692/3/1092006923.geojson
+++ b/data/109/200/692/3/1092006923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.38783,
-    "geom:area_square_m":4580161357.695859,
+    "geom:area_square_m":4580161300.517904,
     "geom:bbox":"-68.380254,-17.589804,-67.37238,-16.751997",
     "geom:latitude":-17.237871,
     "geom:longitude":-67.881311,
@@ -151,9 +151,10 @@
         "hasc:id":"BO.LP.AR",
         "wd:id":"Q490997"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896823,
-    "wof:geomhash":"edc41bc01d9a866a507be275bb88678f",
+    "wof:geomhash":"42bf0e9194130256ada1338e97d8c972",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":1092006923,
-    "wof:lastmodified":1690860318,
+    "wof:lastmodified":1695886179,
     "wof:name":"Aroma",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/109/200/696/9/1092006969.geojson
+++ b/data/109/200/696/9/1092006969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.265726,
-    "geom:area_square_m":3172570829.080644,
+    "geom:area_square_m":3172570479.75452,
     "geom:bbox":"-69.21241,-15.385241,-68.333948,-14.763324",
     "geom:latitude":-15.081568,
     "geom:longitude":-68.810462,
@@ -142,9 +142,10 @@
         "hasc:id":"BO.LP.BS",
         "wd:id":"Q1166108"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896824,
-    "wof:geomhash":"90c577794a16575db5ddd0e49676775d",
+    "wof:geomhash":"51ac356560aa3cd6204e29c7b729b21c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1092006969,
-    "wof:lastmodified":1690860330,
+    "wof:lastmodified":1695886198,
     "wof:name":"Bautista Saavedra",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/109/200/700/3/1092007003.geojson
+++ b/data/109/200/700/3/1092007003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149702,
-    "geom:area_square_m":1783470476.565269,
+    "geom:area_square_m":1783470753.310282,
     "geom:bbox":"-69.34114,-15.896341,-68.907165,-15.255014",
     "geom:latitude":-15.534178,
     "geom:longitude":-69.095609,
@@ -132,9 +132,10 @@
         "hasc:id":"BO.LP.CM",
         "wd:id":"Q863138"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896826,
-    "wof:geomhash":"38e01d56c63d073d311a9272fed52d6a",
+    "wof:geomhash":"a0c6f8861caed1413df772415724ee70",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1092007003,
-    "wof:lastmodified":1690860313,
+    "wof:lastmodified":1695886173,
     "wof:name":"Camacho",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/109/200/705/1/1092007051.geojson
+++ b/data/109/200/705/1/1092007051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.219228,
-    "geom:area_square_m":2609034869.958585,
+    "geom:area_square_m":2609034869.958902,
     "geom:bbox":"-67.6828722048,-16.0584211131,-67.1344710918,-15.3310581071",
     "geom:latitude":-15.748474,
     "geom:longitude":-67.44851,
@@ -94,9 +94,10 @@
     "wof:concordances":{
         "hasc:id":"BO.LP.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896828,
-    "wof:geomhash":"16c3fd85ed43f3f7782b296482df485a",
+    "wof:geomhash":"a4e0c160d884a6ca76bf489ae8b8673d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1092007051,
-    "wof:lastmodified":1566617447,
+    "wof:lastmodified":1695886187,
     "wof:name":"Caranavi",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/109/200/713/3/1092007133.geojson
+++ b/data/109/200/713/3/1092007133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.154378,
-    "geom:area_square_m":1823454176.104585,
+    "geom:area_square_m":1823454545.618229,
     "geom:bbox":"-69.644827,-17.491314,-69.021956,-16.960525",
     "geom:latitude":-17.208283,
     "geom:longitude":-69.332106,
@@ -131,9 +131,10 @@
         "hasc:id":"BO.LP.PC",
         "wd:id":"Q1355941"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896831,
-    "wof:geomhash":"075fc01dd30357574625717343c256b5",
+    "wof:geomhash":"27981d934bfec28ff67d99733f1ee7cc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1092007133,
-    "wof:lastmodified":1690860319,
+    "wof:lastmodified":1695886181,
     "wof:name":"General Jose Manuel",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/109/200/716/5/1092007165.geojson
+++ b/data/109/200/716/5/1092007165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170765,
-    "geom:area_square_m":2012204825.86277,
+    "geom:area_square_m":2012204897.895459,
     "geom:bbox":"-68.289396,-17.881714,-67.507989,-17.419395",
     "geom:latitude":-17.644797,
     "geom:longitude":-67.889981,
@@ -143,9 +143,10 @@
         "hasc:id":"BO.LP.GV",
         "wd:id":"Q731115"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896832,
-    "wof:geomhash":"ae7c566028f491cf26a091057840b139",
+    "wof:geomhash":"f48279926bc390fc780e39fa13990ca7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1092007165,
-    "wof:lastmodified":1690860336,
+    "wof:lastmodified":1695886208,
     "wof:name":"Gualberto Villarroe",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/109/200/721/3/1092007213.geojson
+++ b/data/109/200/721/3/1092007213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.348808,
-    "geom:area_square_m":4129611389.368977,
+    "geom:area_square_m":4129610878.958201,
     "geom:bbox":"-69.324192,-17.097441,-68.14693,-16.368319",
     "geom:latitude":-16.771227,
     "geom:longitude":-68.773028,
@@ -145,9 +145,10 @@
         "hasc:id":"BO.LP.IG",
         "wd:id":"Q1355971"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896834,
-    "wof:geomhash":"9bdb22265c9a9c945bec3589b6965626",
+    "wof:geomhash":"8f564e0fef667c32abfed0dfb7a4c323",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1092007213,
-    "wof:lastmodified":1690860333,
+    "wof:lastmodified":1695886203,
     "wof:name":"Ingavi",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/109/200/725/7/1092007257.geojson
+++ b/data/109/200/725/7/1092007257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.607226,
-    "geom:area_square_m":7185170618.177658,
+    "geom:area_square_m":7185170411.730907,
     "geom:bbox":"-67.541185,-17.64175,-66.732113,-16.245133",
     "geom:latitude":-16.87131,
     "geom:longitude":-67.096316,
@@ -145,9 +145,10 @@
         "hasc:id":"BO.LP.IQ",
         "wd:id":"Q1325725"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896836,
-    "wof:geomhash":"a3b54ed25f2a1f85779ea750e1ced976",
+    "wof:geomhash":"ebab7a19f17e701949706a0ad8dc2435",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1092007257,
-    "wof:lastmodified":1690860319,
+    "wof:lastmodified":1695886180,
     "wof:name":"Inquisivi",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/109/200/745/9/1092007459.geojson
+++ b/data/109/200/745/9/1092007459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.150029,
-    "geom:area_square_m":1781642227.28685,
+    "geom:area_square_m":1781642402.548877,
     "geom:bbox":"-67.967154,-16.402101,-67.339305,-16.00119",
     "geom:latitude":-16.181443,
     "geom:longitude":-67.692477,
@@ -133,9 +133,10 @@
         "hasc:id":"BO.LP.NY",
         "wd:id":"Q389311"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896843,
-    "wof:geomhash":"469af4b87fee85fe8b5333e0355d5cc1",
+    "wof:geomhash":"546bc2f7f6ebd79e42f634e13c347799",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1092007459,
-    "wof:lastmodified":1690860335,
+    "wof:lastmodified":1695886207,
     "wof:name":"Nor Yungas",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/109/200/750/7/1092007507.geojson
+++ b/data/109/200/750/7/1092007507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119168,
-    "geom:area_square_m":1416351168.94872,
+    "geom:area_square_m":1416351050.143756,
     "geom:bbox":"-68.99656,-16.255486,-68.494691,-15.754521",
     "geom:latitude":-16.013804,
     "geom:longitude":-68.71818,
@@ -136,9 +136,10 @@
         "hasc:id":"BO.LP.OM",
         "wd:id":"Q951271"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896845,
-    "wof:geomhash":"12c143406aab7dbbae741f0f2f949964",
+    "wof:geomhash":"2a31f30c919590f6379670677ae83aa2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1092007507,
-    "wof:lastmodified":1690860325,
+    "wof:lastmodified":1695886189,
     "wof:name":"Omasuyos",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/109/200/760/9/1092007609.geojson
+++ b/data/109/200/760/9/1092007609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110088,
-    "geom:area_square_m":1288310937.705189,
+    "geom:area_square_m":1288310734.11964,
     "geom:bbox":"-67.267097,-19.200177,-66.860916,-18.447642",
     "geom:latitude":-18.841056,
     "geom:longitude":-67.049331,
@@ -129,9 +129,10 @@
         "hasc:id":"BO.OR.AV",
         "wd:id":"Q1427732"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896849,
-    "wof:geomhash":"7ec79562a392d507ed74800b8e81516d",
+    "wof:geomhash":"1477f371e8fd9ce903a098d504d65e12",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1092007609,
-    "wof:lastmodified":1690860324,
+    "wof:lastmodified":1695886188,
     "wof:name":"Lago Poopo",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/765/9/1092007659.geojson
+++ b/data/109/200/765/9/1092007659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.26813,
-    "geom:area_square_m":3186297218.447879,
+    "geom:area_square_m":3186298314.806644,
     "geom:bbox":"-69.40919,-16.680834,-68.567064,-15.53695",
     "geom:latitude":-16.044246,
     "geom:longitude":-69.033534,
@@ -137,9 +137,10 @@
         "hasc:id":"BO.LP.OM",
         "wd:id":"Q951271"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896851,
-    "wof:geomhash":"21cb8a3efa0ed677dc230c02f9c1f003",
+    "wof:geomhash":"98817903b3de79a39b2c9d7923ee15cc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1092007659,
-    "wof:lastmodified":1690860312,
+    "wof:lastmodified":1695886171,
     "wof:name":"Lago Titicaca",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/109/200/772/7/1092007727.geojson
+++ b/data/109/200/772/7/1092007727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018233,
-    "geom:area_square_m":214292574.733128,
+    "geom:area_square_m":214292638.901441,
     "geom:bbox":"-67.228578,-18.205369,-67.032339,-18.025441",
     "geom:latitude":-18.107616,
     "geom:longitude":-67.121075,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"BO.OR.CE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896854,
-    "wof:geomhash":"c622d38efe7badf6a0c5fe705f212a84",
+    "wof:geomhash":"17b4a447307595aac6ad998f30756450",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1092007727,
-    "wof:lastmodified":1627521601,
+    "wof:lastmodified":1695886185,
     "wof:name":"Lago Uru Uru",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/777/7/1092007777.geojson
+++ b/data/109/200/777/7/1092007777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.297462,
-    "geom:area_square_m":3477483707.473928,
+    "geom:area_square_m":3477483707.130676,
     "geom:bbox":"-67.0177,-19.46247,-66.077663,-18.589688",
     "geom:latitude":-19.013369,
     "geom:longitude":-66.613517,
@@ -114,9 +114,10 @@
         "hasc:id":"BO.OR.AV",
         "wd:id":"Q1427732"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896855,
-    "wof:geomhash":"5087ea73f73be0ba69e7343d7aea73d8",
+    "wof:geomhash":"de04afd51865d124a7d91973814be4a2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1092007777,
-    "wof:lastmodified":1690860321,
+    "wof:lastmodified":1695886184,
     "wof:name":"Abaroa",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/780/7/1092007807.geojson
+++ b/data/109/200/780/7/1092007807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.359644,
-    "geom:area_square_m":4219692786.74083,
+    "geom:area_square_m":4219693274.277306,
     "geom:bbox":"-68.151564,-18.82365,-67.506831,-18.009654",
     "geom:latitude":-18.399762,
     "geom:longitude":-67.833783,
@@ -124,9 +124,10 @@
         "hasc:id":"BO.OR.CR",
         "wd:id":"Q1420332"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896857,
-    "wof:geomhash":"db7051b5762be27b832eb218de849d7d",
+    "wof:geomhash":"72a4c30408929476d56c148d1856bbc9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1092007807,
-    "wof:lastmodified":1690860334,
+    "wof:lastmodified":1695886205,
     "wof:name":"Carangas",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/789/3/1092007893.geojson
+++ b/data/109/200/789/3/1092007893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.512282,
-    "geom:area_square_m":5975433063.387566,
+    "geom:area_square_m":5975432633.014495,
     "geom:bbox":"-68.094436,-19.88625,-66.987438,-19.049791",
     "geom:latitude":-19.382265,
     "geom:longitude":-67.536711,
@@ -136,9 +136,10 @@
         "hasc:id":"BO.OR.LC",
         "wd:id":"Q1420326"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896860,
-    "wof:geomhash":"52faf5c97ebaac91336c69fe25fea5b8",
+    "wof:geomhash":"8cf6402c0f1e1dbdb9a7d7a19f3f174d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1092007893,
-    "wof:lastmodified":1690860334,
+    "wof:lastmodified":1695886205,
     "wof:name":"Ladislao Cabrera",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/793/9/1092007939.geojson
+++ b/data/109/200/793/9/1092007939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.212332,
-    "geom:area_square_m":2485800118.798544,
+    "geom:area_square_m":2485799709.220102,
     "geom:bbox":"-68.496389,-19.037507,-67.837731,-18.489971",
     "geom:latitude":-18.775851,
     "geom:longitude":-68.202474,
@@ -142,9 +142,10 @@
         "hasc:id":"BO.OR.LT",
         "wd:id":"Q388758"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896862,
-    "wof:geomhash":"d0c7b74b0fe177282e06009a0412b114",
+    "wof:geomhash":"e08d4ee2f16fcf0613d6978afc3c19df",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1092007939,
-    "wof:lastmodified":1690860324,
+    "wof:lastmodified":1695886649,
     "wof:name":"Litoral",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/797/5/1092007975.geojson
+++ b/data/109/200/797/5/1092007975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059068,
-    "geom:area_square_m":690640426.812746,
+    "geom:area_square_m":690640353.255372,
     "geom:bbox":"-68.8412,-19.172204,-68.557205,-18.820963",
     "geom:latitude":-18.990136,
     "geom:longitude":-68.694555,
@@ -143,9 +143,10 @@
         "hasc:id":"BO.OR.AT",
         "wd:id":"Q1425469"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896863,
-    "wof:geomhash":"3e06557700e9f56cb6a043b3ab70a50a",
+    "wof:geomhash":"d548891626ba144529b45764d96aeb23",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1092007975,
-    "wof:lastmodified":1690860308,
+    "wof:lastmodified":1695886645,
     "wof:name":"Mejillones",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/797/7/1092007977.geojson
+++ b/data/109/200/797/7/1092007977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074335,
-    "geom:area_square_m":874553825.406935,
+    "geom:area_square_m":874553793.085585,
     "geom:bbox":"-68.056312,-18.08749,-67.585451,-17.72616",
     "geom:latitude":-17.924784,
     "geom:longitude":-67.82451,
@@ -58,9 +58,10 @@
     "wof:concordances":{
         "hasc:id":"BO.OR.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896864,
-    "wof:geomhash":"63629c41a8b2caf92910c2d076c2f97b",
+    "wof:geomhash":"c9f86f5c64f5b7d2cfd0954209a46c8a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092007977,
-    "wof:lastmodified":1627521602,
+    "wof:lastmodified":1695886187,
     "wof:name":"Nor Carangas",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/797/9/1092007979.geojson
+++ b/data/109/200/797/9/1092007979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073203,
-    "geom:area_square_m":859848599.486059,
+    "geom:area_square_m":859848500.243404,
     "geom:bbox":"-67.092872,-18.433283,-66.527936,-18.036858",
     "geom:latitude":-18.207978,
     "geom:longitude":-66.841541,
@@ -137,9 +137,10 @@
         "hasc:id":"BO.OR.PD",
         "wd:id":"Q1420290"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896866,
-    "wof:geomhash":"f6b675d0b82aca5c5a5acc0206644d96",
+    "wof:geomhash":"f84fe666887688a16fe3f41065040948",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1092007979,
-    "wof:lastmodified":1690860307,
+    "wof:lastmodified":1695886163,
     "wof:name":"Pantaleon Dalence",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/799/1/1092007991.geojson
+++ b/data/109/200/799/1/1092007991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147342,
-    "geom:area_square_m":1727762235.556295,
+    "geom:area_square_m":1727762595.247302,
     "geom:bbox":"-67.105543,-18.790971,-66.694046,-18.212433",
     "geom:latitude":-18.499716,
     "geom:longitude":-66.900038,
@@ -137,9 +137,10 @@
         "hasc:id":"BO.OR.PP",
         "wd:id":"Q1420274"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896868,
-    "wof:geomhash":"56e30c36a974698ef25048436598b736",
+    "wof:geomhash":"f340e0af053f96c2d383b2e7d4eae3e6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1092007991,
-    "wof:lastmodified":1690860310,
+    "wof:lastmodified":1695886168,
     "wof:name":"Poopo",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/803/9/1092008039.geojson
+++ b/data/109/200/803/9/1092008039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.330939,
-    "geom:area_square_m":3870928948.111136,
+    "geom:area_square_m":3870928939.880847,
     "geom:bbox":"-69.014201,-19.433719,-67.893526,-18.521996",
     "geom:latitude":-18.923825,
     "geom:longitude":-68.558793,
@@ -143,9 +143,10 @@
         "hasc:id":"BO.OR.AT",
         "wd:id":"Q1425469"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896870,
-    "wof:geomhash":"21a0bde8b27fd7f31d97123c2864db51",
+    "wof:geomhash":"45dcdfb19a81b1f31dabbd5f103afcc6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1092008039,
-    "wof:lastmodified":1690860318,
+    "wof:lastmodified":1695886647,
     "wof:name":"Sabaya",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/812/3/1092008123.geojson
+++ b/data/109/200/812/3/1092008123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.122188,
-    "geom:area_square_m":1438079697.333789,
+    "geom:area_square_m":1438079547.867265,
     "geom:bbox":"-68.354258,-18.074503,-67.93928,-17.615182",
     "geom:latitude":-17.858242,
     "geom:longitude":-68.180181,
@@ -122,9 +122,10 @@
         "hasc:id":"BO.OR.SJ",
         "wd:id":"Q1425459"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896872,
-    "wof:geomhash":"08a365d1af461933e8e9ed94c308f498",
+    "wof:geomhash":"c7263727846755e7ec797029a0b0596b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092008123,
-    "wof:lastmodified":1690860328,
+    "wof:lastmodified":1695886193,
     "wof:name":"San Pedro De Totora",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/816/7/1092008167.geojson
+++ b/data/109/200/816/7/1092008167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.249018,
-    "geom:area_square_m":2923741786.704173,
+    "geom:area_square_m":2923742077.95179,
     "geom:bbox":"-67.661578,-18.739684,-67.130427,-17.790532",
     "geom:latitude":-18.279778,
     "geom:longitude":-67.414622,
@@ -137,9 +137,10 @@
         "hasc:id":"BO.OR.SA",
         "wd:id":"Q1427714"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896874,
-    "wof:geomhash":"2fc5aeca0ef9cf3f81a233c37e872ad3",
+    "wof:geomhash":"45f7217b70867d62ba6ce251313638f6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1092008167,
-    "wof:lastmodified":1690860314,
+    "wof:lastmodified":1695886174,
     "wof:name":"Saucari",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/821/9/1092008219.geojson
+++ b/data/109/200/821/9/1092008219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.206178,
-    "geom:area_square_m":2408143188.57444,
+    "geom:area_square_m":2408143097.276497,
     "geom:bbox":"-66.904389,-19.414447,-66.191211,-18.866314",
     "geom:latitude":-19.164148,
     "geom:longitude":-66.56738,
@@ -128,9 +128,10 @@
         "hasc:id":"BO.OR.AV",
         "wd:id":"Q1427732"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896876,
-    "wof:geomhash":"8830524f886fea6834f34ba5a701f2e8",
+    "wof:geomhash":"f6aecff6ea32cfdcf21a09e977b55fea",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092008219,
-    "wof:lastmodified":1690860315,
+    "wof:lastmodified":1695886176,
     "wof:name":"Sebastian Pagador",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/824/3/1092008243.geojson
+++ b/data/109/200/824/3/1092008243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.290217,
-    "geom:area_square_m":3395345031.902576,
+    "geom:area_square_m":3395345073.643208,
     "geom:bbox":"-67.965409,-19.099138,-67.056954,-18.587858",
     "geom:latitude":-18.888058,
     "geom:longitude":-67.502043,
@@ -125,9 +125,10 @@
         "hasc:id":"BO.OR.CR",
         "wd:id":"Q1420332"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896877,
-    "wof:geomhash":"2a3c94a771518681fad6849c6543c632",
+    "wof:geomhash":"0e22b3268562b8e880c49caf95e41c3f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1092008243,
-    "wof:lastmodified":1690860328,
+    "wof:lastmodified":1695886193,
     "wof:name":"Sur Carangas",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/828/7/1092008287.geojson
+++ b/data/109/200/828/7/1092008287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028285,
-    "geom:area_square_m":333336978.128201,
+    "geom:area_square_m":333337040.659396,
     "geom:bbox":"-67.549197,-17.734539,-67.306921,-17.505446",
     "geom:latitude":-17.625032,
     "geom:longitude":-67.443674,
@@ -58,9 +58,10 @@
     "wof:concordances":{
         "hasc:id":"BO.OR.CE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896879,
-    "wof:geomhash":"e441f23e7b25d3dad6072b5007e7e661",
+    "wof:geomhash":"d596f00558ecd14617bd749afb73194b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092008287,
-    "wof:lastmodified":1627521602,
+    "wof:lastmodified":1695886187,
     "wof:name":"Tomas Barron",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/832/9/1092008329.geojson
+++ b/data/109/200/832/9/1092008329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.766957,
-    "geom:area_square_m":9321840506.714638,
+    "geom:area_square_m":9321840506.715843,
     "geom:bbox":"-67.5617290092,-11.1059981361,-66.4461857681,-9.89623628305",
     "geom:latitude":-10.593805,
     "geom:longitude":-66.950994,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"BO.PA.GR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896880,
-    "wof:geomhash":"f61805c1a62205f9c0c938144c9cfcc0",
+    "wof:geomhash":"64d0d306df395a6c737a94bf42eb56e5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1092008329,
-    "wof:lastmodified":1566617439,
+    "wof:lastmodified":1695886179,
     "wof:name":"Abuna",
     "wof:parent_id":85669417,
     "wof:placetype":"county",

--- a/data/109/200/841/1/1092008411.geojson
+++ b/data/109/200/841/1/1092008411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.998996,
-    "geom:area_square_m":12095197637.172106,
+    "geom:area_square_m":12095196644.553267,
     "geom:bbox":"-67.997581,-12.496771,-66.094908,-10.90753",
     "geom:latitude":-11.715374,
     "geom:longitude":-67.108048,
@@ -123,9 +123,10 @@
         "hasc:id":"BO.PA.MD",
         "wd:id":"Q241217"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896883,
-    "wof:geomhash":"4e3ae0c240cfcea6d59db1bb05cb746b",
+    "wof:geomhash":"1088a65db99d372bd1fbf08b0360b7f0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1092008411,
-    "wof:lastmodified":1690860326,
+    "wof:lastmodified":1695886190,
     "wof:name":"Madre De Dios",
     "wof:parent_id":85669417,
     "wof:placetype":"county",

--- a/data/109/200/846/1/1092008461.geojson
+++ b/data/109/200/846/1/1092008461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.627505,
-    "geom:area_square_m":19716860857.144394,
+    "geom:area_square_m":19716862057.932735,
     "geom:bbox":"-69.257476,-12.500775,-66.01128,-10.801455",
     "geom:latitude":-11.544594,
     "geom:longitude":-68.008085,
@@ -133,9 +133,10 @@
         "hasc:id":"BO.PA.MN",
         "wd:id":"Q1473356"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896885,
-    "wof:geomhash":"f4e0076890e8daf7e8092cc2aa41d066",
+    "wof:geomhash":"046f9734a1511a793b45421efcee8da0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1092008461,
-    "wof:lastmodified":1690860326,
+    "wof:lastmodified":1695886190,
     "wof:name":"Manuripi",
     "wof:parent_id":85669417,
     "wof:placetype":"county",

--- a/data/109/200/850/1/1092008501.geojson
+++ b/data/109/200/850/1/1092008501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.80676,
-    "geom:area_square_m":9791471367.64328,
+    "geom:area_square_m":9791471335.885017,
     "geom:bbox":"-69.574807,-11.467762,-67.18497,-10.313477",
     "geom:latitude":-11.027089,
     "geom:longitude":-68.380525,
@@ -58,9 +58,10 @@
     "wof:concordances":{
         "hasc:id":"BO.PA.GR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896887,
-    "wof:geomhash":"32a1af71656328260c827d38eda25d62",
+    "wof:geomhash":"c2a2a12a442d908d4eb7878205854da8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092008501,
-    "wof:lastmodified":1627521601,
+    "wof:lastmodified":1695886185,
     "wof:name":"Nicolas Suarez",
     "wof:parent_id":85669417,
     "wof:placetype":"county",

--- a/data/109/200/866/5/1092008665.geojson
+++ b/data/109/200/866/5/1092008665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12014,
-    "geom:area_square_m":1411733051.237584,
+    "geom:area_square_m":1411732827.567023,
     "geom:bbox":"-66.772998,-18.388785,-66.182045,-17.947071",
     "geom:latitude":-18.138006,
     "geom:longitude":-66.428813,
@@ -130,9 +130,10 @@
         "hasc:id":"BO.PO.AI",
         "wd:id":"Q1360913"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896889,
-    "wof:geomhash":"6a3058a6fe46c4c80c83d918d891e241",
+    "wof:geomhash":"fd6ae4d412016f5458892ccd04c7da3f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1092008665,
-    "wof:lastmodified":1690860316,
+    "wof:lastmodified":1695886177,
     "wof:name":"Alonso de Ibanez",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/109/200/873/7/1092008737.geojson
+++ b/data/109/200/873/7/1092008737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.285547,
-    "geom:area_square_m":3352430521.474775,
+    "geom:area_square_m":3352430494.3351,
     "geom:bbox":"-66.28638,-18.615069,-65.345041,-17.970886",
     "geom:latitude":-18.291641,
     "geom:longitude":-65.874961,
@@ -139,9 +139,10 @@
         "hasc:id":"BO.PO.CR",
         "wd:id":"Q936944"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896897,
-    "wof:geomhash":"6ee84f63be57f57b2e537988d96d3bf0",
+    "wof:geomhash":"364b09cbbfe0dc23063a205b063969f8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1092008737,
-    "wof:lastmodified":1690860314,
+    "wof:lastmodified":1695886175,
     "wof:name":"Charcas",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/109/200/879/1/1092008791.geojson
+++ b/data/109/200/879/1/1092008791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.429421,
-    "geom:area_square_m":5027638110.982386,
+    "geom:area_square_m":5027638616.677698,
     "geom:bbox":"-66.338065,-19.07476,-65.399698,-18.424508",
     "geom:latitude":-18.764452,
     "geom:longitude":-65.891355,
@@ -142,9 +142,10 @@
         "hasc:id":"BO.PO.CY",
         "wd:id":"Q733870"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896898,
-    "wof:geomhash":"765afd1a6abb6273e0034e841b604d8a",
+    "wof:geomhash":"924cd6f400d22380133b7d6b2376204b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1092008791,
-    "wof:lastmodified":1690860326,
+    "wof:lastmodified":1695886191,
     "wof:name":"Chayanta",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/109/200/884/3/1092008843.geojson
+++ b/data/109/200/884/3/1092008843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.275312,
-    "geom:area_square_m":3210751791.191019,
+    "geom:area_square_m":3210752423.345122,
     "geom:bbox":"-65.701249,-19.735209,-64.835133,-18.992453",
     "geom:latitude":-19.41187,
     "geom:longitude":-65.35999,
@@ -139,9 +139,10 @@
         "hasc:id":"BO.PO.CS",
         "wd:id":"Q339416"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896900,
-    "wof:geomhash":"f432509c7d697c80c333c3a4cab7a80e",
+    "wof:geomhash":"c2a1be4636144980e314a2575778bdde",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1092008843,
-    "wof:lastmodified":1690860327,
+    "wof:lastmodified":1695886192,
     "wof:name":"Cornelio Saavedra",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/109/200/895/3/1092008953.geojson
+++ b/data/109/200/895/3/1092008953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065574,
-    "geom:area_square_m":771183131.318928,
+    "geom:area_square_m":771183124.659858,
     "geom:bbox":"-66.272857,-18.163804,-65.897193,-17.801214",
     "geom:latitude":-17.992377,
     "geom:longitude":-66.069534,
@@ -141,9 +141,10 @@
         "hasc:id":"BO.PO.GB",
         "wd:id":"Q1360850"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896904,
-    "wof:geomhash":"7b7aa94926eeff3f8950f1c3927c1121",
+    "wof:geomhash":"b5b9298184747ae88f6bcab4ebee1670",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1092008953,
-    "wof:lastmodified":1690860317,
+    "wof:lastmodified":1695886177,
     "wof:name":"General Bernardino",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/109/200/899/1/1092008991.geojson
+++ b/data/109/200/899/1/1092008991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.420073,
-    "geom:area_square_m":4885652723.635115,
+    "geom:area_square_m":4885652080.703075,
     "geom:bbox":"-65.888741,-20.240862,-64.714226,-19.470552",
     "geom:latitude":-19.849804,
     "geom:longitude":-65.312178,
@@ -140,9 +140,10 @@
         "hasc:id":"BO.PO.JL",
         "wd:id":"Q1416432"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896906,
-    "wof:geomhash":"fc4cc794cfdfcfacbd5b12fc9b19d019",
+    "wof:geomhash":"b34c468c5ba54de066cf1c4c93f81ce7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1092008991,
-    "wof:lastmodified":1690860331,
+    "wof:lastmodified":1695886200,
     "wof:name":"Jose Maria Linares",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/109/200/915/3/1092009153.geojson
+++ b/data/109/200/915/3/1092009153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198648,
-    "geom:area_square_m":2329489820.470249,
+    "geom:area_square_m":2329489548.996849,
     "geom:bbox":"-66.741056,-18.771963,-66.177441,-18.178455",
     "geom:latitude":-18.492137,
     "geom:longitude":-66.481175,
@@ -139,9 +139,10 @@
         "hasc:id":"BO.PO.RB",
         "wd:id":"Q1360897"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896912,
-    "wof:geomhash":"b37a69c409a0a3db8a37a5c6cfc7a6d3",
+    "wof:geomhash":"37789e366c49773f76f4feeadcc7d78c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1092009153,
-    "wof:lastmodified":1690860319,
+    "wof:lastmodified":1695886181,
     "wof:name":"Rafael Bustillo",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/109/200/920/3/1092009203.geojson
+++ b/data/109/200/920/3/1092009203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.722963,
-    "geom:area_square_m":8323501427.384342,
+    "geom:area_square_m":8323501732.996183,
     "geom:bbox":"-66.46867,-21.860069,-65.24468,-20.876977",
     "geom:latitude":-21.394338,
     "geom:longitude":-65.893015,
@@ -140,9 +140,10 @@
         "hasc:id":"BO.PO.SC",
         "wd:id":"Q1425463"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896914,
-    "wof:geomhash":"1701d0fc7252d4ab16987782cd1c0e44",
+    "wof:geomhash":"f9cfb9e0d2914fae05322af579b49549",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1092009203,
-    "wof:lastmodified":1690860332,
+    "wof:lastmodified":1695886201,
     "wof:name":"Sur Chichas",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/109/200/931/7/1092009317.geojson
+++ b/data/109/200/931/7/1092009317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.236234,
-    "geom:area_square_m":2755872092.255264,
+    "geom:area_square_m":2755872203.14046,
     "geom:bbox":"-68.605445,-19.693864,-67.700354,-19.036784",
     "geom:latitude":-19.361605,
     "geom:longitude":-68.140825,
@@ -150,9 +150,10 @@
         "hasc:id":"BO.OR.AT",
         "wd:id":"Q1425469"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896919,
-    "wof:geomhash":"37448e330118f414cb2fffb6ee240557",
+    "wof:geomhash":"04fa299e6fef31a7412ca4e0d1a2c2b6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":1092009317,
-    "wof:lastmodified":1690860308,
+    "wof:lastmodified":1695886645,
     "wof:name":"Salar de Coipasa",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/109/200/938/7/1092009387.geojson
+++ b/data/109/200/938/7/1092009387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.891444,
-    "geom:area_square_m":10346717100.618843,
+    "geom:area_square_m":10346717148.987234,
     "geom:bbox":"-68.276771,-20.71655,-66.891077,-19.529769",
     "geom:latitude":-20.171071,
     "geom:longitude":-67.590143,
@@ -132,9 +132,10 @@
         "hasc:id":"BO.PO.NL",
         "wd:id":"Q1319477"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896921,
-    "wof:geomhash":"3574e1b8ebf44cb3e29106fe921541aa",
+    "wof:geomhash":"87a924d3f60b7267217562171109ec8b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1092009387,
-    "wof:lastmodified":1690860309,
+    "wof:lastmodified":1695886164,
     "wof:name":"Salar de Uyuni",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/109/200/951/1/1092009511.geojson
+++ b/data/109/200/951/1/1092009511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.291411,
-    "geom:area_square_m":27058144374.175766,
+    "geom:area_square_m":27058140633.40411,
     "geom:bbox":"-59.527878,-18.079782,-57.636516,-16.262846",
     "geom:latitude":-17.250602,
     "geom:longitude":-58.820726,
@@ -58,9 +58,10 @@
     "wof:concordances":{
         "hasc:id":"BO.SC.VL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896926,
-    "wof:geomhash":"559b7d15145d94f02b51045244c1fb3c",
+    "wof:geomhash":"978185d51eb99b742badb0d59f069702",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1092009511,
-    "wof:lastmodified":1627521600,
+    "wof:lastmodified":1695886183,
     "wof:name":"Angel Sandoval",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/109/200/954/3/1092009543.geojson
+++ b/data/109/200/954/3/1092009543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.422613,
-    "geom:area_square_m":40291573992.229134,
+    "geom:area_square_m":40291571355.348564,
     "geom:bbox":"-62.816052,-18.66968,-58.960925,-17.009051",
     "geom:latitude":-17.814467,
     "geom:longitude":-60.785731,
@@ -139,9 +139,10 @@
         "hasc:id":"BO.SC.CQ",
         "wd:id":"Q1147271"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896927,
-    "wof:geomhash":"25609ee372efb912983dc195459bc8b5",
+    "wof:geomhash":"9a09b159ba04ab7ae53161f43bb6407f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1092009543,
-    "wof:lastmodified":1690860311,
+    "wof:lastmodified":1695886168,
     "wof:name":"Chiquitos",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/109/200/960/1/1092009601.geojson
+++ b/data/109/200/960/1/1092009601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.21181,
-    "geom:area_square_m":84249224776.382202,
+    "geom:area_square_m":84249223801.996323,
     "geom:bbox":"-63.757261,-20.473214,-58.870368,-18.016558",
     "geom:latitude":-19.124907,
     "geom:longitude":-61.861531,
@@ -145,9 +145,10 @@
         "hasc:id":"BO.SC.CR",
         "wd:id":"Q652371"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896929,
-    "wof:geomhash":"05e5e813fd42d7d67812965468872f60",
+    "wof:geomhash":"56548173b103e4826d771a436c6d4065",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1092009601,
-    "wof:lastmodified":1690860325,
+    "wof:lastmodified":1695886649,
     "wof:name":"Cordillera",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/109/200/966/1/1092009661.geojson
+++ b/data/109/200/966/1/1092009661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.41207,
-    "geom:area_square_m":4844590308.112616,
+    "geom:area_square_m":4844590308.113071,
     "geom:bbox":"-64.326035,-18.455004,-63.485129,-17.519424",
     "geom:latitude":-18.047855,
     "geom:longitude":-63.946486,
@@ -169,9 +169,10 @@
         "hasc:id":"BO.SC.FL",
         "wd:id":"Q818"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896931,
-    "wof:geomhash":"c2b4da3387668d1c9d92751c651f4392",
+    "wof:geomhash":"1a85d7b1f82095d1063529cdc7781488",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":1092009661,
-    "wof:lastmodified":1690860323,
+    "wof:lastmodified":1695886648,
     "wof:name":"Florida",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/109/200/973/7/1092009737.geojson
+++ b/data/109/200/973/7/1092009737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.18089,
-    "geom:area_square_m":26001685644.22715,
+    "geom:area_square_m":26001683872.253365,
     "geom:bbox":"-64.727067,-16.42365,-62.768437,-14.11085",
     "geom:latitude":-15.367034,
     "geom:longitude":-63.373434,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"BO.EB.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896934,
-    "wof:geomhash":"9925397499c76657a17c81f5cc237258",
+    "wof:geomhash":"a9ae3da4de109b50e5ccaf654e8df4dd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1092009737,
-    "wof:lastmodified":1627521600,
+    "wof:lastmodified":1695886183,
     "wof:name":"Guarayos",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/109/200/978/5/1092009785.geojson
+++ b/data/109/200/978/5/1092009785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.235167,
-    "geom:area_square_m":14609302662.510607,
+    "geom:area_square_m":14609302503.239059,
     "geom:bbox":"-64.839253,-18.025218,-63.458784,-15.802045",
     "geom:latitude":-16.946673,
     "geom:longitude":-64.170618,
@@ -139,9 +139,10 @@
         "hasc:id":"BO.SC.IC",
         "wd:id":"Q1215525"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896936,
-    "wof:geomhash":"ff7686278f8a32554922d2c83fefc3f2",
+    "wof:geomhash":"48205c06e6f1f51a2e12ecc287c96e13",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1092009785,
-    "wof:lastmodified":1690860320,
+    "wof:lastmodified":1695886182,
     "wof:name":"Ichilo",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/109/200/987/3/1092009873.geojson
+++ b/data/109/200/987/3/1092009873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.362643,
-    "geom:area_square_m":51917173008.971176,
+    "geom:area_square_m":51917171753.330261,
     "geom:bbox":"-63.45562,-17.525375,-61.369149,-13.759605",
     "geom:latitude":-15.732201,
     "geom:longitude":-62.292994,
@@ -130,9 +130,10 @@
         "hasc:id":"BO.SC.NC",
         "wd:id":"Q1215592"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896939,
-    "wof:geomhash":"f989c60c2a653a7d8b5c7110665e0225",
+    "wof:geomhash":"7bce43ef5c78f57eb34e8a861ec005b2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1092009873,
-    "wof:lastmodified":1690860333,
+    "wof:lastmodified":1695886202,
     "wof:name":"Nuflo De Chavez",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/109/200/989/9/1092009899.geojson
+++ b/data/109/200/989/9/1092009899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.432973,
-    "geom:area_square_m":5126964409.498692,
+    "geom:area_square_m":5126964351.833764,
     "geom:bbox":"-64.230275,-17.418886,-63.023551,-16.042761",
     "geom:latitude":-16.734705,
     "geom:longitude":-63.454765,
@@ -140,9 +140,10 @@
         "hasc:id":"BO.SC.OS",
         "wd:id":"Q1215579"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896941,
-    "wof:geomhash":"2ea8c231d04a50149534a303b2e63481",
+    "wof:geomhash":"36e3e0c12b9d54333f9f47ed999a5e09",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1092009899,
-    "wof:lastmodified":1690860334,
+    "wof:lastmodified":1695886204,
     "wof:name":"Obispo Santisteban",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/109/200/995/9/1092009959.geojson
+++ b/data/109/200/995/9/1092009959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.465063,
-    "geom:area_square_m":5503646362.494466,
+    "geom:area_square_m":5503646706.026173,
     "geom:bbox":"-64.524878,-17.633386,-63.196898,-15.950099",
     "geom:latitude":-16.846649,
     "geom:longitude":-63.731375,
@@ -136,9 +136,10 @@
         "hasc:id":"BO.SC.SG",
         "wd:id":"Q1215541"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896944,
-    "wof:geomhash":"0d85f48aa159d3997e583f1543575da1",
+    "wof:geomhash":"38639ea423078275cdeb6b3877a696fd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1092009959,
-    "wof:lastmodified":1690860323,
+    "wof:lastmodified":1695886187,
     "wof:name":"Sara",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/109/201/002/5/1092010025.geojson
+++ b/data/109/201/002/5/1092010025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.758214,
-    "geom:area_square_m":68586234830.5056,
+    "geom:area_square_m":68586234755.570473,
     "geom:bbox":"-62.144669,-17.402521,-59.495547,-13.476198",
     "geom:latitude":-15.538285,
     "geom:longitude":-60.909788,
@@ -114,9 +114,10 @@
         "hasc:id":"BO.SC.VL",
         "wd:id":"Q1215518"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896947,
-    "wof:geomhash":"3c3fecf0f8440dfa07b961ce9d6ca7db",
+    "wof:geomhash":"22db172deb4e99b9f6b3b797c4d3ab86",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1092010025,
-    "wof:lastmodified":1690860338,
+    "wof:lastmodified":1695886210,
     "wof:name":"Velasco",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/109/201/008/3/1092010083.geojson
+++ b/data/109/201/008/3/1092010083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.200614,
-    "geom:area_square_m":2367389624.991886,
+    "geom:area_square_m":2367389307.617455,
     "geom:bbox":"-63.268058,-17.684736,-62.725025,-17.035606",
     "geom:latitude":-17.378154,
     "geom:longitude":-62.979628,
@@ -135,9 +135,10 @@
         "hasc:id":"BO.SC.WR",
         "wd:id":"Q1215506"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896949,
-    "wof:geomhash":"f4ef6cd2954753b0b62a91c57786ad4f",
+    "wof:geomhash":"36d2eb71cba72e214f200af9ab248b58",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1092010083,
-    "wof:lastmodified":1690860337,
+    "wof:lastmodified":1695886209,
     "wof:name":"Warnes",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/109/201/013/7/1092010137.geojson
+++ b/data/109/201/013/7/1092010137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.230081,
-    "geom:area_square_m":2641955620.778301,
+    "geom:area_square_m":2641955015.285962,
     "geom:bbox":"-65.419242,-22.085651,-64.482549,-21.479175",
     "geom:latitude":-21.776836,
     "geom:longitude":-65.025806,
@@ -123,9 +123,10 @@
         "hasc:id":"BO.TR.AV",
         "wd:id":"Q1409118"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896952,
-    "wof:geomhash":"0b866aa066bd8a82bc95744cdf7d39e1",
+    "wof:geomhash":"cc41efab09094188ad0b36c43b47a080",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1092010137,
-    "wof:lastmodified":1690860336,
+    "wof:lastmodified":1695886209,
     "wof:name":"Avilez",
     "wof:parent_id":85669431,
     "wof:placetype":"county",

--- a/data/109/201/019/1/1092010191.geojson
+++ b/data/109/201/019/1/1092010191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.438606,
-    "geom:area_square_m":5048787891.61903,
+    "geom:area_square_m":5048787427.742664,
     "geom:bbox":"-64.440734,-21.955906,-63.647594,-20.88733",
     "geom:latitude":-21.420304,
     "geom:longitude":-64.100424,
@@ -133,9 +133,10 @@
         "hasc:id":"BO.TR.OC",
         "wd:id":"Q1478034"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896954,
-    "wof:geomhash":"2f63c0f89eca328897f20b676fb0bf46",
+    "wof:geomhash":"dbd08ba5c95d5078695eb49501a9967a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1092010191,
-    "wof:lastmodified":1690860337,
+    "wof:lastmodified":1695886211,
     "wof:name":"Burnet O'Connor",
     "wof:parent_id":85669431,
     "wof:placetype":"county",

--- a/data/109/201/028/7/1092010287.geojson
+++ b/data/109/201/028/7/1092010287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.350292,
-    "geom:area_square_m":4036708940.663196,
+    "geom:area_square_m":4036708988.661067,
     "geom:bbox":"-65.249947,-21.617009,-64.390423,-20.931364",
     "geom:latitude":-21.257311,
     "geom:longitude":-64.876988,
@@ -123,9 +123,10 @@
         "hasc:id":"BO.TR.MD",
         "wd:id":"Q1473342"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1473896958,
-    "wof:geomhash":"298571d2d1cc0514cecb29c22866c09b",
+    "wof:geomhash":"bf48c9bca0f0d8e41ec27fafcbb315a0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1092010287,
-    "wof:lastmodified":1690860337,
+    "wof:lastmodified":1695886209,
     "wof:name":"Mendez",
     "wof:parent_id":85669431,
     "wof:placetype":"county",

--- a/data/421/166/639/421166639.geojson
+++ b/data/421/166/639/421166639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.708942,
-    "geom:area_square_m":8205127988.15949,
+    "geom:area_square_m":8205129424.250404,
     "geom:bbox":"-66.279128,-21.166145,-65.21704,-20.028636",
     "geom:latitude":-20.608804,
     "geom:longitude":-65.710221,
@@ -171,12 +171,13 @@
         "wd:id":"Q1360821",
         "wk:page":"Nor Chichas Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459008697,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d49f715da8938be51653f7dfe3536c06",
+    "wof:geomhash":"2291c24463e3b7fed8e762a146f3d882",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":421166639,
-    "wof:lastmodified":1690860340,
+    "wof:lastmodified":1695886564,
     "wof:name":"Nor Chichas",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/168/083/421168083.geojson
+++ b/data/421/168/083/421168083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.747365,
-    "geom:area_square_m":8887140074.079288,
+    "geom:area_square_m":8887139647.496256,
     "geom:bbox":"-67.954757,-16.74249,-66.802798,-14.922203",
     "geom:latitude":-15.907143,
     "geom:longitude":-67.295961,
@@ -178,12 +178,13 @@
         "wd:id":"Q609394",
         "wk:page":"Sud Yungas Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459008753,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"13655a0c5646a91a3ea0d727bbb940ec",
+    "wof:geomhash":"17227663629724ef0dc98103f81f6f0f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -193,7 +194,7 @@
         }
     ],
     "wof:id":421168083,
-    "wof:lastmodified":1690860339,
+    "wof:lastmodified":1695886565,
     "wof:name":"Sur Yungas",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/169/225/421169225.geojson
+++ b/data/421/169/225/421169225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146996,
-    "geom:area_square_m":1719095948.760995,
+    "geom:area_square_m":1719096402.077812,
     "geom:bbox":"-64.508967,-19.224083,-64.022492,-18.614446",
     "geom:latitude":-18.951869,
     "geom:longitude":-64.298812,
@@ -169,12 +169,13 @@
         "wd:id":"Q638697",
         "wk:page":"Belisario Boeto Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459008800,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b10b8dc75a110481ad27e37434a41aa2",
+    "wof:geomhash":"6215cec6d60a075118c40261da7d523c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -184,7 +185,7 @@
         }
     ],
     "wof:id":421169225,
-    "wof:lastmodified":1690860345,
+    "wof:lastmodified":1695886571,
     "wof:name":"Belisario Boeto",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/421/169/227/421169227.geojson
+++ b/data/421/169/227/421169227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.367835,
-    "geom:area_square_m":4289687601.462419,
+    "geom:area_square_m":4289687047.509832,
     "geom:bbox":"-64.662144,-19.889799,-63.954748,-18.880627",
     "geom:latitude":-19.415152,
     "geom:longitude":-64.318543,
@@ -171,12 +171,13 @@
         "qs_pg:id":1200746,
         "wd:id":"Q1420320"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459008800,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0581e404bc8a3da8c8c050cc04b9f77e",
+    "wof:geomhash":"eac41b057b508a8d9d21df9c203bb1e9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":421169227,
-    "wof:lastmodified":1690860344,
+    "wof:lastmodified":1695886570,
     "wof:name":"Tomina",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/421/169/233/421169233.geojson
+++ b/data/421/169/233/421169233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.185934,
-    "geom:area_square_m":2138202111.224134,
+    "geom:area_square_m":2138202947.555808,
     "geom:bbox":"-65.011637,-21.869021,-64.331717,-21.237378",
     "geom:latitude":-21.562576,
     "geom:longitude":-64.59734,
@@ -138,12 +138,13 @@
         "wd:id":"Q328661",
         "wk:page":"Cercado Province (Tarija)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459008800,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c00a1637059df320f109aad9e316fc88",
+    "wof:geomhash":"92f8a28212f517962aff3f6c818699b5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":421169233,
-    "wof:lastmodified":1690860344,
+    "wof:lastmodified":1695886571,
     "wof:name":"Cercado",
     "wof:parent_id":85669431,
     "wof:placetype":"county",

--- a/data/421/169/235/421169235.geojson
+++ b/data/421/169/235/421169235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.618598,
-    "geom:area_square_m":18615409692.129875,
+    "geom:area_square_m":18615410437.15395,
     "geom:bbox":"-64.319157,-22.346337,-62.260665,-21.003653",
     "geom:latitude":-21.545853,
     "geom:longitude":-63.194847,
@@ -162,12 +162,13 @@
         "wd:id":"Q267695",
         "wk:page":"Gran Chaco Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459008800,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5cf5b1a5010b8a8e5a42627c1779e118",
+    "wof:geomhash":"503d2d3d4fbebf0926c40f1371e502cf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":421169235,
-    "wof:lastmodified":1690860344,
+    "wof:lastmodified":1695886570,
     "wof:name":"Gran Chaco",
     "wof:parent_id":85669431,
     "wof:placetype":"county",

--- a/data/421/172/489/421172489.geojson
+++ b/data/421/172/489/421172489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.30621,
-    "geom:area_square_m":15478360679.356604,
+    "geom:area_square_m":15478359987.708546,
     "geom:bbox":"-66.332973,-17.50246,-64.725425,-15.789168",
     "geom:latitude":-16.595529,
     "geom:longitude":-65.559201,
@@ -165,12 +165,13 @@
         "wd:id":"Q1434538",
         "wk:page":"Chapare Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459008944,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7fdf3ca0a6c4eeb72d9fa5ab3c08124b",
+    "wof:geomhash":"85638a87ae1f661ddac58070e098a7f2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":421172489,
-    "wof:lastmodified":1690860354,
+    "wof:lastmodified":1695886575,
     "wof:name":"Chapare",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/421/175/057/421175057.geojson
+++ b/data/421/175/057/421175057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.183593,
-    "geom:area_square_m":2112227328.605017,
+    "geom:area_square_m":2112227756.977583,
     "geom:bbox":"-67.72343,-21.856901,-67.134757,-21.109531",
     "geom:latitude":-21.497141,
     "geom:longitude":-67.431143,
@@ -132,12 +132,13 @@
         "qs_pg:id":349595,
         "wd:id":"Q1360868"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009053,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"053f5865ba7b0842bce6dad50c26564f",
+    "wof:geomhash":"da16e8beac705893aad15b872b64af26",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421175057,
-    "wof:lastmodified":1690860357,
+    "wof:lastmodified":1695886577,
     "wof:name":"Enrique Baldivieso",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/177/651/421177651.geojson
+++ b/data/421/177/651/421177651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017172,
-    "geom:area_square_m":202418037.554803,
+    "geom:area_square_m":202418063.754422,
     "geom:bbox":"-66.082823,-17.716781,-65.872835,-17.476003",
     "geom:latitude":-17.577648,
     "geom:longitude":-65.960637,
@@ -168,12 +168,13 @@
         "qs_pg:id":1347428,
         "wd:id":"Q1424407"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009156,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"574fa1fd60d2abdabd84ce3c31dc5d43",
+    "wof:geomhash":"90c4a8cceb74b25ef7110e85fefb2c26",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":421177651,
-    "wof:lastmodified":1690860363,
+    "wof:lastmodified":1695886579,
     "wof:name":"German Jordan",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/421/177/655/421177655.geojson
+++ b/data/421/177/655/421177655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.078854,
-    "geom:area_square_m":13127217026.15575,
+    "geom:area_square_m":13127218969.254843,
     "geom:bbox":"-66.592211,-10.853701,-65.28681,-9.669633",
     "geom:latitude":-10.248964,
     "geom:longitude":-65.962768,
@@ -147,12 +147,13 @@
         "qs_pg:id":1347477,
         "wd:id":"Q1473313"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009156,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"29470aead2686170740a208939970d0d",
+    "wof:geomhash":"0f0b702b5ca3b283cb037d27e6b3411d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":421177655,
-    "wof:lastmodified":1690860366,
+    "wof:lastmodified":1695886583,
     "wof:name":"Federico Roman",
     "wof:parent_id":85669417,
     "wof:placetype":"county",

--- a/data/421/177/657/421177657.geojson
+++ b/data/421/177/657/421177657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.479224,
-    "geom:area_square_m":17177252048.340261,
+    "geom:area_square_m":17177251392.307543,
     "geom:bbox":"-67.270831,-20.997305,-65.756785,-19.35601",
     "geom:latitude":-20.092804,
     "geom:longitude":-66.541492,
@@ -179,12 +179,13 @@
         "qs_pg:id":1347484,
         "wd:id":"Q1360766"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009156,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0fdfe39107a6991547470228d3bbcc8",
+    "wof:geomhash":"d63e367f89b6872f46be4842941fbb97",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -194,7 +195,7 @@
         }
     ],
     "wof:id":421177657,
-    "wof:lastmodified":1690860365,
+    "wof:lastmodified":1695886582,
     "wof:name":"Antonio Quijarro",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/177/659/421177659.geojson
+++ b/data/421/177/659/421177659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.593374,
-    "geom:area_square_m":6890159119.676464,
+    "geom:area_square_m":6890160230.746648,
     "geom:bbox":"-68.774038,-20.720733,-67.57141,-19.436504",
     "geom:latitude":-20.100771,
     "geom:longitude":-68.329004,
@@ -163,12 +163,13 @@
         "qs_pg:id":1347485,
         "wd:id":"Q938354"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009157,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"68dc82fa63752ed17c093c347beff16d",
+    "wof:geomhash":"fa70b756c0550bb332a21c24263841a0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":421177659,
-    "wof:lastmodified":1690860364,
+    "wof:lastmodified":1695886580,
     "wof:name":"Daniel Campos",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/177/661/421177661.geojson
+++ b/data/421/177/661/421177661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.215579,
-    "geom:area_square_m":2473049947.210589,
+    "geom:area_square_m":2473049980.869318,
     "geom:bbox":"-66.130722,-22.111693,-65.180511,-21.668347",
     "geom:latitude":-21.914561,
     "geom:longitude":-65.640702,
@@ -180,12 +180,13 @@
         "qs_pg:id":1347486,
         "wd:id":"Q120514"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009157,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c785824c5b8d913eab86c6c7abdb5fe3",
+    "wof:geomhash":"741dadea0aed9d817e66593da7c4d327",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":421177661,
-    "wof:lastmodified":1690860365,
+    "wof:lastmodified":1695886583,
     "wof:name":"Modesto Omiste",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/177/665/421177665.geojson
+++ b/data/421/177/665/421177665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.419238,
-    "geom:area_square_m":4889541878.711479,
+    "geom:area_square_m":4889541313.499612,
     "geom:bbox":"-66.406371,-19.816666,-65.544458,-19.005219",
     "geom:latitude":-19.402197,
     "geom:longitude":-65.93988,
@@ -176,12 +176,13 @@
         "qs_pg:id":1347523,
         "wd:id":"Q1339683"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009157,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"92463ac4c4f8146d5420c1c69fae2923",
+    "wof:geomhash":"efc216b1561ed853daa3b116988005ce",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":421177665,
-    "wof:lastmodified":1690860366,
+    "wof:lastmodified":1695886584,
     "wof:name":"Tomas Frias",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/177/667/421177667.geojson
+++ b/data/421/177/667/421177667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.32157,
-    "geom:area_square_m":3814644343.417772,
+    "geom:area_square_m":3814644949.411393,
     "geom:bbox":"-68.305092,-16.860646,-67.619086,-15.758642",
     "geom:latitude":-16.390227,
     "geom:longitude":-67.973052,
@@ -166,12 +166,13 @@
         "qs_pg:id":1347526,
         "wd:id":"Q590873"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009157,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ee5b569bf88cf2576df410892a8bcdcc",
+    "wof:geomhash":"94a14d480530d815f2b2fdf555bc8c17",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":421177667,
-    "wof:lastmodified":1690860363,
+    "wof:lastmodified":1695886579,
     "wof:name":"Murillo",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/182/435/421182435.geojson
+++ b/data/421/182/435/421182435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.238796,
-    "geom:area_square_m":2823394949.621167,
+    "geom:area_square_m":2823394591.081091,
     "geom:bbox":"-68.037518,-17.447284,-67.293685,-16.662547",
     "geom:latitude":-17.022381,
     "geom:longitude":-67.611875,
@@ -168,12 +168,13 @@
         "wd:id":"Q1424412",
         "wk:page":"Loayza Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009329,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"63400aba41e61a4469d6f4c24b619ab7",
+    "wof:geomhash":"c83da3c07d4a3c9e2340432829d92bfd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":421182435,
-    "wof:lastmodified":1690860368,
+    "wof:lastmodified":1695886585,
     "wof:name":"Loayza",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/182/437/421182437.geojson
+++ b/data/421/182/437/421182437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.126408,
-    "geom:area_square_m":1506604629.651797,
+    "geom:area_square_m":1506604571.456809,
     "geom:bbox":"-68.968576,-15.803081,-68.437258,-15.151365",
     "geom:latitude":-15.444615,
     "geom:longitude":-68.766108,
@@ -170,12 +170,13 @@
         "wd:id":"Q1355881",
         "wk:page":"Mu\u00f1ecas Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009329,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b7e39ada46552002a6b5a8e9b4365c51",
+    "wof:geomhash":"2a82f43c775afa5cc656456a78c3db8d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":421182437,
-    "wof:lastmodified":1690860367,
+    "wof:lastmodified":1695886586,
     "wof:name":"Munecas",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/182/439/421182439.geojson
+++ b/data/421/182/439/421182439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.964132,
-    "geom:area_square_m":11373824931.449486,
+    "geom:area_square_m":11373825537.82152,
     "geom:bbox":"-69.469031,-18.053321,-68.08957,-16.781116",
     "geom:latitude":-17.435089,
     "geom:longitude":-68.778648,
@@ -156,12 +156,13 @@
         "wd:id":"Q1355941",
         "wk:page":"Pacajes Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009330,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f4c5e3e3b8fa7641aa926f4a92e55ff0",
+    "wof:geomhash":"420ab42d77e502e67d6463315b616ba6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":421182439,
-    "wof:lastmodified":1690860367,
+    "wof:lastmodified":1695886584,
     "wof:name":"Pacajes",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/182/443/421182443.geojson
+++ b/data/421/182/443/421182443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.42145,
-    "geom:area_square_m":4825724873.994602,
+    "geom:area_square_m":4825724947.355252,
     "geom:bbox":"-65.056236,-22.880182,-64.100419,-21.795411",
     "geom:latitude":-22.177659,
     "geom:longitude":-64.514637,
@@ -152,12 +152,13 @@
         "wd:id":"Q679350",
         "wk:page":"Aniceto Arce Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009330,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b6b2257dad46565b60e18ce680594df9",
+    "wof:geomhash":"84b218f62908485e0a09f965f016632c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421182443,
-    "wof:lastmodified":1690860368,
+    "wof:lastmodified":1695886586,
     "wof:name":"Arce",
     "wof:parent_id":85669431,
     "wof:placetype":"county",

--- a/data/421/183/095/421183095.geojson
+++ b/data/421/183/095/421183095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.169077,
-    "geom:area_square_m":25392689266.372749,
+    "geom:area_square_m":25392694885.291687,
     "geom:bbox":"-59.250338,-20.165863,-57.454433,-17.970812",
     "geom:latitude":-18.774908,
     "geom:longitude":-58.356682,
@@ -171,12 +171,13 @@
         "qs_pg:id":961920,
         "wd:id":"Q734606"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009357,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1c50ca366698123afca5502f24423ea3",
+    "wof:geomhash":"423f23c1fa7e0ff952bb129da41007ea",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":421183095,
-    "wof:lastmodified":1690860367,
+    "wof:lastmodified":1695886585,
     "wof:name":"German Busch",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/421/185/047/421185047.geojson
+++ b/data/421/185/047/421185047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112107,
-    "geom:area_square_m":1320165592.650211,
+    "geom:area_square_m":1320165641.363549,
     "geom:bbox":"-66.179096,-17.996656,-65.717206,-17.472099",
     "geom:latitude":-17.758946,
     "geom:longitude":-65.956176,
@@ -171,12 +171,13 @@
         "wd:id":"Q283889",
         "wk:page":"Esteban Arce Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009431,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"faac9fd9eb8c34faeb1bfab2f0b31e24",
+    "wof:geomhash":"0c49e39c9e261efbaf1e837fe9d6d78b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":421185047,
-    "wof:lastmodified":1690860370,
+    "wof:lastmodified":1695886587,
     "wof:name":"Esteban Arce",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/421/186/229/421186229.geojson
+++ b/data/421/186/229/421186229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.289019,
-    "geom:area_square_m":3401740784.401551,
+    "geom:area_square_m":3401740903.927618,
     "geom:bbox":"-64.819462,-18.235978,-64.207956,-17.421704",
     "geom:latitude":-17.849275,
     "geom:longitude":-64.478496,
@@ -168,12 +168,13 @@
         "qs_pg:id":1062250,
         "wd:id":"Q1215606"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009474,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"17c99532fa7420f875efabd55085c5b8",
+    "wof:geomhash":"938806eaba589b9be52d14f0a49dfa21",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":421186229,
-    "wof:lastmodified":1690860354,
+    "wof:lastmodified":1695886576,
     "wof:name":"Manuel M. Caballero",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/421/187/093/421187093.geojson
+++ b/data/421/187/093/421187093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.375571,
-    "geom:area_square_m":16454711816.07881,
+    "geom:area_square_m":16454713543.047792,
     "geom:bbox":"-69.363095,-15.249087,-67.38808,-13.931796",
     "geom:latitude":-14.667531,
     "geom:longitude":-68.366113,
@@ -137,12 +137,13 @@
         "qs_pg:id":1080248,
         "wd:id":"Q2367617"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009501,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a8bbba1623d28ddc88ef6947110b96e3",
+    "wof:geomhash":"1e3ad587233b29b977c2e167b79fa86c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421187093,
-    "wof:lastmodified":1690860350,
+    "wof:lastmodified":1695886572,
     "wof:name":"Franz Tamayo",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/187/909/421187909.geojson
+++ b/data/421/187/909/421187909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021187,
-    "geom:area_square_m":251622915.426106,
+    "geom:area_square_m":251623006.848332,
     "geom:bbox":"-69.232345,-16.30235,-68.802566,-15.953169",
     "geom:latitude":-16.160996,
     "geom:longitude":-69.010962,
@@ -171,12 +171,13 @@
         "wd:id":"Q1325738",
         "wk:page":"Manco Kapac Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009527,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d5fe3b3e61f6b9147a3308e6eae9921f",
+    "wof:geomhash":"44c44a2d4eec866b061f26c39536dd8e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":421187909,
-    "wof:lastmodified":1690860349,
+    "wof:lastmodified":1695886573,
     "wof:name":"Manco Kapac",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/187/923/421187923.geojson
+++ b/data/421/187/923/421187923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.404881,
-    "geom:area_square_m":4764416265.467095,
+    "geom:area_square_m":4764416567.292834,
     "geom:bbox":"-63.646758,-18.27145,-62.748636,-17.508098",
     "geom:latitude":-17.887353,
     "geom:longitude":-63.202034,
@@ -193,12 +193,13 @@
         "wd:id":"Q582935",
         "wk:page":"Andr\u00e9s Ib\u00e1\u00f1ez Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009528,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4fb74879daf962c06f3cda87848875db",
+    "wof:geomhash":"f265bc7970b2270cd10d78fc7940797c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":421187923,
-    "wof:lastmodified":1690860349,
+    "wof:lastmodified":1695886573,
     "wof:name":"Andres Ibanez",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/421/187/927/421187927.geojson
+++ b/data/421/187/927/421187927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.435763,
-    "geom:area_square_m":5128166192.900427,
+    "geom:area_square_m":5128165915.581566,
     "geom:bbox":"-67.731506,-18.577855,-66.712267,-17.323932",
     "geom:latitude":-17.873951,
     "geom:longitude":-67.169132,
@@ -129,12 +129,13 @@
         "wd:id":"Q590859",
         "wk:page":"Cercado Province (Oruro)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009528,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"753d87c2f718f5e08be2a832eaa543a4",
+    "wof:geomhash":"fea4d00d67be8d321266408d28a72189",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421187927,
-    "wof:lastmodified":1690860351,
+    "wof:lastmodified":1695886574,
     "wof:name":"Cercado",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/421/187/929/421187929.geojson
+++ b/data/421/187/929/421187929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.851556,
-    "geom:area_square_m":10142115509.153675,
+    "geom:area_square_m":10142115000.85639,
     "geom:bbox":"-68.854894,-16.106023,-67.472322,-15.123657",
     "geom:latitude":-15.59126,
     "geom:longitude":-68.16875,
@@ -175,12 +175,13 @@
         "wd:id":"Q1325760",
         "wk:page":"Larecaja Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009528,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"50f77ee467efd581d29c1adc40241934",
+    "wof:geomhash":"489ca82a252a365de247a2c4497a165f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -190,7 +191,7 @@
         }
     ],
     "wof:id":421187929,
-    "wof:lastmodified":1690860350,
+    "wof:lastmodified":1695886575,
     "wof:name":"Larecaja",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/188/855/421188855.geojson
+++ b/data/421/188/855/421188855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139795,
-    "geom:area_square_m":1632786898.393535,
+    "geom:area_square_m":1632787319.107118,
     "geom:bbox":"-65.206281,-19.385715,-64.723143,-18.858466",
     "geom:latitude":-19.164478,
     "geom:longitude":-64.971151,
@@ -176,12 +176,13 @@
         "wd:id":"Q1420314",
         "wk:page":"Yampar\u00e1ez Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009583,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6260aa0b863e9c126ff05a6abf2746f0",
+    "wof:geomhash":"1ee42fecbe027a654392d4f2c5c9d99e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":421188855,
-    "wof:lastmodified":1690860353,
+    "wof:lastmodified":1695886576,
     "wof:name":"Yamparaez",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/421/190/241/421190241.geojson
+++ b/data/421/190/241/421190241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.314203,
-    "geom:area_square_m":3676923098.673194,
+    "geom:area_square_m":3676922695.928562,
     "geom:bbox":"-65.695004,-19.375006,-65.007063,-18.345948",
     "geom:latitude":-18.843243,
     "geom:longitude":-65.308006,
@@ -666,12 +666,13 @@
         "qs_pg:id":1119108,
         "wd:id":"Q1420303"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009651,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ad708c93e54bb7027068b09b3eb1c8e8",
+    "wof:geomhash":"02d3f7181d33a8ec6e830901b4d7f6f7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -681,7 +682,7 @@
         }
     ],
     "wof:id":421190241,
-    "wof:lastmodified":1690860359,
+    "wof:lastmodified":1695886578,
     "wof:name":"Oropeza",
     "wof:parent_id":85669399,
     "wof:placetype":"county",

--- a/data/421/190/243/421190243.geojson
+++ b/data/421/190/243/421190243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024553,
-    "geom:area_square_m":289668411.423226,
+    "geom:area_square_m":289668427.035575,
     "geom:bbox":"-66.280267,-17.534055,-66.067174,-17.278124",
     "geom:latitude":-17.426108,
     "geom:longitude":-66.169344,
@@ -141,12 +141,13 @@
         "wd:id":"Q200795",
         "wk:page":"Cercado Province (Cochabamba)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009652,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2db3ac40954e5c3ac8d88bc079f4c00d",
+    "wof:geomhash":"67aa162654291be3a8bd6f6cf780a90b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":421190243,
-    "wof:lastmodified":1690860359,
+    "wof:lastmodified":1695886577,
     "wof:name":"Cercado",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/421/190/245/421190245.geojson
+++ b/data/421/190/245/421190245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.337824,
-    "geom:area_square_m":40183710688.53157,
+    "geom:area_square_m":40183711303.135307,
     "geom:bbox":"-69.072211,-14.603454,-66.920392,-11.857086",
     "geom:latitude":-13.178139,
     "geom:longitude":-67.999832,
@@ -175,12 +175,13 @@
         "wd:id":"Q1355914",
         "wk:page":"Abel Iturralde Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009652,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"465451f0b5c5799aa0fbd563393e3fff",
+    "wof:geomhash":"989a69bd8fdbed28f9185233f00d189f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -190,7 +191,7 @@
         }
     ],
     "wof:id":421190245,
-    "wof:lastmodified":1690860358,
+    "wof:lastmodified":1695886577,
     "wof:name":"Abel Iturralde",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/191/613/421191613.geojson
+++ b/data/421/191/613/421191613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.898475,
-    "geom:area_square_m":10753894301.895065,
+    "geom:area_square_m":10753900816.560181,
     "geom:bbox":"-65.119646,-15.074093,-63.756706,-13.979852",
     "geom:latitude":-14.542917,
     "geom:longitude":-64.491203,
@@ -134,12 +134,13 @@
         "qs_pg:id":74566,
         "wd:id":"Q120891"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009698,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"57e0fa72ae19611d99ca2c3c24b0429c",
+    "wof:geomhash":"edce1cbf8db259c1407f9eb22d27efdc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421191613,
-    "wof:lastmodified":1690860358,
+    "wof:lastmodified":1695886578,
     "wof:name":"Cercado",
     "wof:parent_id":85669403,
     "wof:placetype":"county",

--- a/data/421/193/355/421193355.geojson
+++ b/data/421/193/355/421193355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.590431,
-    "geom:area_square_m":18217888056.382133,
+    "geom:area_square_m":18217888092.736019,
     "geom:bbox":"-68.077675,-22.906568,-66.22278,-21.296617",
     "geom:latitude":-22.121916,
     "geom:longitude":-67.165214,
@@ -180,12 +180,13 @@
         "wd:id":"Q537564",
         "wk:page":"Sur L\u00edpez Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009768,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c81658c4aa0bb0a28f106ae26ed6eed4",
+    "wof:geomhash":"25493528e8bee699ab17fc92459e0f22",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":421193355,
-    "wof:lastmodified":1690860342,
+    "wof:lastmodified":1695886566,
     "wof:name":"Sur Lipez",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/193/357/421193357.geojson
+++ b/data/421/193/357/421193357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.757199,
-    "geom:area_square_m":20269422993.733185,
+    "geom:area_square_m":20269421964.471302,
     "geom:bbox":"-68.569135,-21.930294,-66.275589,-20.395365",
     "geom:latitude":-21.111291,
     "geom:longitude":-67.49094,
@@ -167,12 +167,13 @@
         "wd:id":"Q1319477",
         "wk:page":"Nor L\u00edpez Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009768,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4c7ceeb9b1e6133b555049223fe14e9b",
+    "wof:geomhash":"84db6d9231b986249f27d2fafcd67739",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":421193357,
-    "wof:lastmodified":1690860343,
+    "wof:lastmodified":1695886568,
     "wof:name":"Nor Lipez",
     "wof:parent_id":85669421,
     "wof:placetype":"county",

--- a/data/421/193/471/421193471.geojson
+++ b/data/421/193/471/421193471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.522619,
-    "geom:area_square_m":6122228148.916579,
+    "geom:area_square_m":6122227985.198139,
     "geom:bbox":"-64.494877,-19.184845,-63.523674,-18.159674",
     "geom:latitude":-18.668484,
     "geom:longitude":-63.993803,
@@ -169,12 +169,13 @@
         "qs_pg:id":902719,
         "wd:id":"Q1215562"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009772,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"23609134d93b056575988b7009ae80e8",
+    "wof:geomhash":"8a404041384f85edc4b19d896f2853c8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -184,7 +185,7 @@
         }
     ],
     "wof:id":421193471,
-    "wof:lastmodified":1690860342,
+    "wof:lastmodified":1695886567,
     "wof:name":"Valle Grande",
     "wof:parent_id":85669427,
     "wof:placetype":"county",

--- a/data/421/197/123/421197123.geojson
+++ b/data/421/197/123/421197123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138434,
-    "geom:area_square_m":1634229580.870407,
+    "geom:area_square_m":1634229344.877862,
     "geom:bbox":"-66.535051,-17.707338,-66.094707,-17.044989",
     "geom:latitude":-17.309799,
     "geom:longitude":-66.325804,
@@ -176,12 +176,13 @@
         "qs_pg:id":1311734,
         "wd:id":"Q947724"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009903,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6a76545201d23cdc2414d97542438e40",
+    "wof:geomhash":"88a080e3bbdd457df60bcd248d9f65bd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":421197123,
-    "wof:lastmodified":1690860360,
+    "wof:lastmodified":1695886650,
     "wof:name":"Quillacollo",
     "wof:parent_id":85669395,
     "wof:placetype":"county",

--- a/data/421/197/575/421197575.geojson
+++ b/data/421/197/575/421197575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231133,
-    "geom:area_square_m":2742137345.846323,
+    "geom:area_square_m":2742137312.479482,
     "geom:bbox":"-68.780707,-16.773523,-68.153723,-16.008144",
     "geom:latitude":-16.369949,
     "geom:longitude":-68.440556,
@@ -139,12 +139,13 @@
         "wd:id":"Q1355950",
         "wk:page":"Los Andes Province (Bolivia)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459009918,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b905e2dc76576b75b7fe8e6f39e12a0",
+    "wof:geomhash":"ba46f08663395cd841fb4c10118f7d11",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":421197575,
-    "wof:lastmodified":1690860360,
+    "wof:lastmodified":1695886650,
     "wof:name":"Los Andes",
     "wof:parent_id":85669409,
     "wof:placetype":"county",

--- a/data/421/204/017/421204017.geojson
+++ b/data/421/204/017/421204017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.657704,
-    "geom:area_square_m":7725426430.31803,
+    "geom:area_square_m":7725426207.500992,
     "geom:bbox":"-69.142341,-18.625643,-67.905484,-17.593356",
     "geom:latitude":-18.206828,
     "geom:longitude":-68.576688,
@@ -114,12 +114,13 @@
         "wd:id":"Q1427724",
         "wk:page":"Nor Carangas Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BO",
     "wof:created":1459010171,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f627263c47e39057acc7744a2816ac50",
+    "wof:geomhash":"d5f3f2204fb8b9299b37df89cfbc45e9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421204017,
-    "wof:lastmodified":1690860346,
+    "wof:lastmodified":1695886572,
     "wof:name":"Sajama",
     "wof:parent_id":85669413,
     "wof:placetype":"county",

--- a/data/856/326/23/85632623.geojson
+++ b/data/856/326/23/85632623.geojson
@@ -1189,6 +1189,7 @@
         "hasc:id":"BO",
         "icao:code":"CP",
         "ioc:id":"BOL",
+        "iso:code":"BO",
         "itu:id":"BOL",
         "loc:id":"n79066590",
         "m49:code":"068",
@@ -1203,6 +1204,7 @@
         "wk:page":"Bolivia",
         "wmo:id":"BO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BO",
     "wof:country_alpha3":"BOL",
     "wof:geom_alt":[
@@ -1228,7 +1230,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1694639507,
+    "wof:lastmodified":1695881162,
     "wof:name":"Bolivia",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/693/95/85669395.geojson
+++ b/data/856/693/95/85669395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.888288,
-    "geom:area_square_m":57743156981.767197,
+    "geom:area_square_m":57743155049.247093,
     "geom:bbox":"-67.005779,-18.682883,-64.188217,-15.673504",
     "geom:latitude":-17.181415,
     "geom:longitude":-65.619581,
@@ -352,17 +352,19 @@
         "gn:id":3919966,
         "gp:id":2344802,
         "hasc:id":"BO.CB",
+        "iso:code":"BO-C",
         "iso:id":"BO-C",
         "qs_pg:id":423602,
         "unlc:id":"BO-C",
         "wd:id":"Q233917",
         "wk:page":"Cochabamba Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"906f9e28678a5f572325db894b53cfaa",
+    "wof:geomhash":"e61d2b5185920a2f860a6fdd96ce55f2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -381,7 +383,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1690860298,
+    "wof:lastmodified":1695884791,
     "wof:name":"Cochabamba",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/693/99/85669399.geojson
+++ b/data/856/693/99/85669399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.40065,
-    "geom:area_square_m":51113757508.935776,
+    "geom:area_square_m":51113757675.461075,
     "geom:bbox":"-65.695004,-21.506912,-62.191836,-18.345948",
     "geom:latitude":-20.046245,
     "geom:longitude":-64.287063,
@@ -345,17 +345,19 @@
         "gn:id":3920177,
         "gp:id":2344801,
         "hasc:id":"BO.CQ",
+        "iso:code":"BO-H",
         "iso:id":"BO-H",
         "qs_pg:id":219508,
         "unlc:id":"BO-H",
         "wd:id":"Q235110",
         "wk:page":"Chuquisaca Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4eedc10dd6d901c3f0e1fe2b9ac72aa8",
+    "wof:geomhash":"584ba75e60e735a9dfc91ef6093b06b4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -374,7 +376,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1690860299,
+    "wof:lastmodified":1695884792,
     "wof:name":"Chuquisaca",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/03/85669403.geojson
+++ b/data/856/694/03/85669403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":17.037897,
-    "geom:area_square_m":204589408179.402435,
+    "geom:area_square_m":204589413903.957001,
     "geom:bbox":"-67.566214,-16.418886,-61.527452,-10.381218",
     "geom:latitude":-13.749783,
     "geom:longitude":-65.273388,
@@ -346,17 +346,19 @@
         "gn:id":3923172,
         "gp:id":2344803,
         "hasc:id":"BO.EB",
+        "iso:code":"BO-B",
         "iso:id":"BO-B",
         "qs_pg:id":423603,
         "unlc:id":"BO-B",
         "wd:id":"Q233169",
         "wk:page":"Beni Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"af5cda551e085722e0a90dcea0ec30f8",
+    "wof:geomhash":"6ab2a8b3b0b86aac35096541c97e261e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -375,7 +377,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1690860292,
+    "wof:lastmodified":1695884786,
     "wof:name":"El Beni",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/09/85669409.geojson
+++ b/data/856/694/09/85669409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.056532,
-    "geom:area_square_m":131859877051.466431,
+    "geom:area_square_m":131859880347.74704,
     "geom:bbox":"-69.644827,-18.053321,-66.732113,-11.857086",
     "geom:latitude":-15.233041,
     "geom:longitude":-68.129046,
@@ -359,17 +359,19 @@
         "gn:id":3911924,
         "gp:id":2344804,
         "hasc:id":"BO.LP",
+        "iso:code":"BO-L",
         "iso:id":"BO-L",
         "qs_pg:id":222809,
         "unlc:id":"BO-L",
         "wd:id":"Q272784",
         "wk:page":"La Paz Department (Bolivia)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0f148c962f628909ef02422e4b6b999c",
+    "wof:geomhash":"24b8c07d1b6ffd042ebfd64eb5fd6507",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -388,7 +390,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1690860296,
+    "wof:lastmodified":1695884788,
     "wof:name":"La Paz",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/13/85669413.geojson
+++ b/data/856/694/13/85669413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.420517,
-    "geom:area_square_m":51792858610.646744,
+    "geom:area_square_m":51792857980.102898,
     "geom:bbox":"-69.142341,-19.88625,-66.077663,-17.323932",
     "geom:latitude":-18.633941,
     "geom:longitude":-67.694588,
@@ -343,17 +343,19 @@
         "gn:id":3909233,
         "gp:id":2344805,
         "hasc:id":"BO.OR",
+        "iso:code":"BO-O",
         "iso:id":"BO-O",
         "qs_pg:id":318300,
         "unlc:id":"BO-O",
         "wd:id":"Q1061368",
         "wk:page":"Oruro Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de920b7f2710adc9907c0f064949b4f9",
+    "wof:geomhash":"684d359eaf1c5f65b6c53afd40e083b8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -372,7 +374,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1690860297,
+    "wof:lastmodified":1695884790,
     "wof:name":"Oruro",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/17/85669417.geojson
+++ b/data/856/694/17/85669417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.279072,
-    "geom:area_square_m":64052587396.118416,
+    "geom:area_square_m":64052587601.348885,
     "geom:bbox":"-69.574807,-12.500775,-65.28681,-9.669633",
     "geom:latitude":-11.094912,
     "geom:longitude":-67.323115,
@@ -346,17 +346,19 @@
         "gn:id":3908600,
         "gp:id":2344806,
         "hasc:id":"BO.PA",
+        "iso:code":"BO-N",
         "iso:id":"BO-N",
         "qs_pg:id":318301,
         "unlc:id":"BO-N",
         "wd:id":"Q235362",
         "wk:page":"Pando Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"65086b17a70e960f7a4dd9f9d496d595",
+    "wof:geomhash":"16ce43c0b1e1cd6075dc2628e614dc86",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -375,7 +377,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1690860293,
+    "wof:lastmodified":1695884788,
     "wof:name":"Pando",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/21/85669421.geojson
+++ b/data/856/694/21/85669421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.358619,
-    "geom:area_square_m":119916078030.205017,
+    "geom:area_square_m":119916079105.587326,
     "geom:bbox":"-68.774038,-22.906568,-64.714226,-17.801214",
     "geom:latitude":-20.545905,
     "geom:longitude":-66.729627,
@@ -356,17 +356,19 @@
         "gn:id":3907580,
         "gp:id":2344807,
         "hasc:id":"BO.PO",
+        "iso:code":"BO-P",
         "iso:id":"BO-P",
         "qs_pg:id":222807,
         "unlc:id":"BO-P",
         "wd:id":"Q238079",
         "wk:page":"Potos\u00ed Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9584dc72c4ba00c199c0264cbec1c7be",
+    "wof:geomhash":"849fdd61b143998f19e34b074395ef9f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -385,7 +387,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1690860294,
+    "wof:lastmodified":1695884332,
     "wof:name":"Potos\u00ed",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/27/85669427.geojson
+++ b/data/856/694/27/85669427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":31.359064,
-    "geom:area_square_m":370237004394.733459,
+    "geom:area_square_m":370236999684.90387,
     "geom:bbox":"-64.839253,-20.473214,-57.454433,-13.476198",
     "geom:latitude":-17.215547,
     "geom:longitude":-61.522096,
@@ -358,17 +358,19 @@
         "gn:id":3904907,
         "gp:id":2344808,
         "hasc:id":"BO.SC",
+        "iso:code":"BO-S",
         "iso:id":"BO-S",
         "qs_pg:id":219509,
         "unlc:id":"BO-S",
         "wd:id":"Q235106",
         "wk:page":"Santa Cruz Department (Bolivia)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1779c5d57d2790fd827e1cf5fec32e3e",
+    "wof:geomhash":"4a1db1e633808a393834f12c15303eea",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -387,7 +389,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1690860292,
+    "wof:lastmodified":1695884787,
     "wof:name":"Santa Cruz",
     "wof:parent_id":85632623,
     "wof:placetype":"region",

--- a/data/856/694/31/85669431.geojson
+++ b/data/856/694/31/85669431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.24496,
-    "geom:area_square_m":37306789134.150726,
+    "geom:area_square_m":37306789772.11525,
     "geom:bbox":"-65.419242,-22.880182,-62.260665,-20.88733",
     "geom:latitude":-21.597129,
     "geom:longitude":-63.880432,
@@ -349,17 +349,19 @@
         "gn:id":3903319,
         "gp:id":2344809,
         "hasc:id":"BO.TR",
+        "iso:code":"BO-T",
         "iso:id":"BO-T",
         "qs_pg:id":219510,
         "unlc:id":"BO-T",
         "wd:id":"Q233933",
         "wk:page":"Tarija Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7a2b16e6f2fdef1b4e299bf92b4b47eb",
+    "wof:geomhash":"445d07e9c4a9a51b1e38847e29af03e9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -378,7 +380,7 @@
         "que",
         "aym"
     ],
-    "wof:lastmodified":1690860296,
+    "wof:lastmodified":1695884789,
     "wof:name":"Tarija",
     "wof:parent_id":85632623,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.